### PR TITLE
validation logger syntax fix

### DIFF
--- a/gmnspy/validation/schema_to_df.py
+++ b/gmnspy/validation/schema_to_df.py
@@ -44,7 +44,7 @@ def apply_schema_to_df(
     if not schema_file:
         schema_filename = os.path.split(originating_file)[-1].split(".")[0] + ".schema.json"
         schema_file = join(join(dirname(realpath(__file__)), "../spec"), schema_filename)
-    logger.info("SCHEMA", schema_file)
+    logger.info("SCHEMA: {}".format(schema_file))
     logger.info("...validating {} against {}".format(df, schema_file))
     schema = read_schema(schema_file=schema_file)
 


### PR DESCRIPTION
## Code Submission Checklist

- [X] All public API changes, usage, and architecture changes are documented
- [x] All functions and modules have been documented using [google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
- [x] Code and documentation linted: `pre-commit run --all-files`
- [x] Code for this PR is covered in tests
- [x] Code passes all tests: `pytest`
- [x] By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).

## Documentation Submission Checklist

- [ ] Documentation can be built locally `mkdocs build`
- [ ] Documentation has been reviewed locally `mkdocs serve`
- [ ] By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).

## Issues List

 -  closes #35
