### PR TITLE
feat(semantics): connectivity + geometry assembly + TOD resolution (#76)

### DIFF
--- a/packages/gmnspy/gmnspy/semantics/__init__.py
+++ b/packages/gmnspy/gmnspy/semantics/__init__.py
@@ -1,1 +1,43 @@
-"""GMNS-aware operations: connectivity, geometry assembly, TOD resolution."""
+"""GMNS-domain semantics — connectivity, geometry assembly, TOD resolution.
+
+Three loosely-coupled submodules, one concern each:
+
+* :mod:`gmnspy.semantics.connectivity` — :func:`is_connected`,
+  :func:`connected_components`, :func:`largest_component`,
+  :func:`unreachable_from`. Built on :class:`gmnspy.indexes.GraphIndex`;
+  the index is cached on ``Network.metadata`` so repeat calls don't
+  rebuild.
+* :mod:`gmnspy.semantics.geometry` — :func:`assemble_link_geometry`
+  resolves ``link.geometry`` / ``link.geometry_id`` / node-endpoint
+  fallback and stamps each row with its source.
+* :mod:`gmnspy.semantics.tod` — :func:`resolve_link_attrs_at` overlays
+  ``link_tod`` overrides for a given time period;
+  :func:`tod_coverage` audits which periods have TOD data.
+
+All three materialise through pyarrow (via the underlying engine's
+``to_pandas`` then ``pa.Table.from_pandas``) — consistent with
+:mod:`gmnspy.indexes` and chosen for legibility over an ibis-only API
+that would require an ibis-backed engine.
+"""
+
+from .connectivity import (
+    connected_components,
+    is_connected,
+    largest_component,
+    unreachable_from,
+)
+from .errors import SemanticsError
+from .geometry import GeometrySource, assemble_link_geometry
+from .tod import resolve_link_attrs_at, tod_coverage
+
+__all__ = [
+    "GeometrySource",
+    "SemanticsError",
+    "assemble_link_geometry",
+    "connected_components",
+    "is_connected",
+    "largest_component",
+    "resolve_link_attrs_at",
+    "tod_coverage",
+    "unreachable_from",
+]

--- a/packages/gmnspy/gmnspy/semantics/connectivity.py
+++ b/packages/gmnspy/gmnspy/semantics/connectivity.py
@@ -1,0 +1,147 @@
+"""Network connectivity helpers built on :class:`gmnspy.indexes.GraphIndex`.
+
+All entry points take a :class:`gmnspy.Network`, build (or reuse) a
+graph index, and answer a connectivity question. The index is cached
+on the network's ``metadata`` dict under ``_cached_graph_index`` so
+repeat calls inside a session do not rebuild — see
+:func:`_get_or_build_graph_index`.
+
+Examples:
+    >>> from gmnspy import Network
+    >>> from gmnspy.fixtures import leavenworth
+    >>> from datagrove.engines.pandas_engine import PandasEngine
+    >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+    >>> from gmnspy.semantics import is_connected
+    >>> is_connected(net)
+    True
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gmnspy.indexes import GraphIndex
+    from gmnspy.network import Network
+
+__all__ = [
+    "connected_components",
+    "is_connected",
+    "largest_component",
+    "unreachable_from",
+]
+
+# The key under which we stash the built GraphIndex on Network.metadata.
+# Lives at module scope so the scope module (task 3.10) can reuse it
+# instead of building a parallel cache.
+_GRAPH_INDEX_KEY = "_cached_graph_index"
+
+
+def _get_or_build_graph_index(net: Network) -> GraphIndex:
+    """Return a cached :class:`GraphIndex` or build + cache one.
+
+    Building requires both the ``link`` and ``node`` tables; we let
+    :class:`Network` raise :class:`gmnspy.NetworkError` on its own if
+    either is missing.
+    """
+    cached = net.metadata.get(_GRAPH_INDEX_KEY)
+    if cached is not None:
+        return cached
+    # Local import to keep the cold-import cost of `semantics` low —
+    # callers who never touch connectivity don't pay for igraph.
+    from gmnspy.indexes import GraphIndex
+
+    index = GraphIndex.build(net.links, net.nodes)
+    net.metadata[_GRAPH_INDEX_KEY] = index
+    return index
+
+
+def is_connected(net: Network) -> bool:
+    """Return ``True`` iff the network has exactly one weakly-connected component.
+
+    "Weakly connected" means we ignore link direction — a one-way pair
+    of streets between two nodes counts as connected.
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> is_connected(net)
+        True
+    """
+    return len(connected_components(net)) == 1
+
+
+def connected_components(net: Network) -> list[set[int]]:
+    """Return the network's weakly-connected components, largest first.
+
+    Each component is a set of node_ids. Sorted by ``len`` descending
+    so ``connected_components(net)[0]`` is always the largest. Empty
+    networks return ``[]``.
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> comps = connected_components(net)
+        >>> len(comps) >= 1
+        True
+        >>> all(len(comps[i]) >= len(comps[i + 1]) for i in range(len(comps) - 1))
+        True
+    """
+    index = _get_or_build_graph_index(net)
+    if len(index) == 0:
+        return []
+    # igraph returns positional indices; map back to node ids and sort.
+    raw = index.graph.connected_components(mode="weak")
+    comps = [{index.node_ids[p] for p in comp} for comp in raw]
+    comps.sort(key=len, reverse=True)
+    return comps
+
+
+def largest_component(net: Network) -> set[int]:
+    """Return the set of node_ids in the largest weakly-connected component.
+
+    Empty networks return ``set()``.
+    """
+    comps = connected_components(net)
+    return comps[0] if comps else set()
+
+
+def unreachable_from(net: Network, source_node_id: int) -> set[int]:
+    """Return node_ids that cannot be reached by **directed** traversal from ``source_node_id``.
+
+    Unlike :func:`connected_components` (which ignores direction), this
+    walks the directed graph: a node only counts as reachable if there
+    is a directed path of one-way links from the source.
+
+    A missing ``source_node_id`` raises :class:`SemanticsError` —
+    callers should validate ids against ``net.nodes`` first when they
+    can't guarantee membership.
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> # Pick any node, query — Leavenworth is bidirectional so the
+        >>> # unreachable set is typically empty.
+        >>> seed = next(iter(largest_component(net)))
+        >>> isinstance(unreachable_from(net, seed), set)
+        True
+    """
+    from gmnspy.semantics.errors import SemanticsError
+
+    index = _get_or_build_graph_index(net)
+    pos = index._pos.get(int(source_node_id))
+    if pos is None:
+        raise SemanticsError(
+            f"source_node_id={source_node_id!r} not present in network.nodes (network has {len(index)} nodes)."
+        )
+    # igraph's `subcomponent` with mode="out" walks directed edges.
+    reachable_positions = set(index.graph.subcomponent(pos, mode="out"))
+    all_positions = set(range(len(index)))
+    unreachable_positions = all_positions - reachable_positions
+    return {index.node_ids[p] for p in unreachable_positions}

--- a/packages/gmnspy/gmnspy/semantics/errors.py
+++ b/packages/gmnspy/gmnspy/semantics/errors.py
@@ -1,0 +1,17 @@
+"""Typed exceptions for :mod:`gmnspy.semantics`."""
+
+from __future__ import annotations
+
+from gmnspy.network import NetworkError
+
+__all__ = ["SemanticsError"]
+
+
+class SemanticsError(NetworkError):
+    """A GMNS-semantics operation cannot be performed on the given network.
+
+    Subclass of :class:`gmnspy.NetworkError` so generic handlers still
+    catch it, while callers that care about the source of the failure
+    (connectivity vs. geometry vs. TOD) can branch on the more specific
+    type.
+    """

--- a/packages/gmnspy/gmnspy/semantics/geometry.py
+++ b/packages/gmnspy/gmnspy/semantics/geometry.py
@@ -1,0 +1,164 @@
+"""Link-geometry assembly — resolve ``link.geometry`` / ``link.geometry_id`` / node endpoints.
+
+GMNS allows three ways to carry a link's geometry, in priority order:
+
+1. Inline ``link.geometry`` (WKT) — wins when present + non-empty.
+2. ``link.geometry_id`` resolving to a row in the ``geometry`` table.
+3. Fall back to a straight :code:`LINESTRING(x1 y1, x2 y2)` synthesised
+   from the link's ``from_node_id`` / ``to_node_id`` node coordinates.
+
+:func:`assemble_link_geometry` walks all three in order and stamps each
+output row with a ``source`` column so callers can audit how the
+geometry was produced.
+
+This module materialises through pyarrow (via the underlying
+:class:`~datagrove.dataset.Table`'s engine) rather than expressing the
+resolution chain in ibis. Reason: the geometry table is typically tiny
+relative to links, the join is one-shot, and the pyarrow code reads
+top-to-bottom in 60 lines instead of a 4-arm ibis ``case`` builder.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gmnspy.network import Network
+
+__all__ = ["GeometrySource", "assemble_link_geometry"]
+
+
+class GeometrySource:
+    """Enum-ish constants for the ``source`` column produced by :func:`assemble_link_geometry`."""
+
+    INLINE = "inline"
+    GEOMETRY_TABLE = "geometry_table"
+    NODE_ENDPOINTS = "node_endpoints"
+    MISSING = "missing"
+
+
+def assemble_link_geometry(net: Network) -> pa.Table:
+    """Return ``(link_id, geometry_wkt, source)`` for every link in ``net``.
+
+    Resolution order per link row:
+
+    1. Inline ``link.geometry`` (non-null, non-empty WKT) — ``source = "inline"``.
+    2. ``link.geometry_id`` resolving in ``net.geometry`` — ``source = "geometry_table"``.
+    3. Straight ``LINESTRING(x1 y1, x2 y2)`` from ``from_node_id`` /
+       ``to_node_id`` looked up in ``net.nodes`` — ``source = "node_endpoints"``.
+    4. None of the above (geometry column absent + geometry_id absent +
+       endpoint nodes missing coords) — ``geometry_wkt = None``,
+       ``source = "missing"``.
+
+    Args:
+        net: A loaded :class:`gmnspy.Network`.
+
+    Returns:
+        A :class:`pyarrow.Table` with columns ``link_id`` (matching
+        the link table's id type), ``geometry_wkt`` (string or null),
+        and ``source`` (string from :class:`GeometrySource`).
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> from gmnspy.semantics import assemble_link_geometry
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> tbl = assemble_link_geometry(net)
+        >>> set(tbl.column_names) == {"link_id", "geometry_wkt", "source"}
+        True
+        >>> # Leavenworth carries geometry via geometry_id, so all rows
+        >>> # should resolve through the geometry table.
+        >>> set(tbl.column("source").to_pylist()) <= {"inline", "geometry_table", "node_endpoints", "missing"}
+        True
+    """
+    links_arrow = _to_arrow(net.links)
+    geom_lookup = _build_geometry_lookup(net)
+    node_lookup = _build_node_xy_lookup(net)
+
+    link_ids: list = []
+    geom_wkts: list[str | None] = []
+    sources: list[str] = []
+
+    has_inline_geom = "geometry" in links_arrow.column_names
+    has_geom_id = "geometry_id" in links_arrow.column_names
+
+    inline_col = links_arrow.column("geometry").to_pylist() if has_inline_geom else None
+    geom_id_col = links_arrow.column("geometry_id").to_pylist() if has_geom_id else None
+    from_col = links_arrow.column("from_node_id").to_pylist()
+    to_col = links_arrow.column("to_node_id").to_pylist()
+    id_col = links_arrow.column("link_id").to_pylist()
+
+    for i, link_id in enumerate(id_col):
+        link_ids.append(link_id)
+
+        # 1. Inline geometry wins.
+        if inline_col is not None:
+            wkt = inline_col[i]
+            if wkt is not None and str(wkt).strip():
+                geom_wkts.append(str(wkt))
+                sources.append(GeometrySource.INLINE)
+                continue
+
+        # 2. geometry_id lookup.
+        if geom_id_col is not None:
+            gid = geom_id_col[i]
+            if gid is not None and gid in geom_lookup:
+                geom_wkts.append(geom_lookup[gid])
+                sources.append(GeometrySource.GEOMETRY_TABLE)
+                continue
+
+        # 3. Synthesize from node endpoints.
+        from_id, to_id = from_col[i], to_col[i]
+        if from_id in node_lookup and to_id in node_lookup:
+            x1, y1 = node_lookup[from_id]
+            x2, y2 = node_lookup[to_id]
+            if None not in (x1, y1, x2, y2):
+                geom_wkts.append(f"LINESTRING ({x1} {y1}, {x2} {y2})")
+                sources.append(GeometrySource.NODE_ENDPOINTS)
+                continue
+
+        # 4. Truly unresolvable — emit a null + flag for the audit.
+        geom_wkts.append(None)
+        sources.append(GeometrySource.MISSING)
+
+    return pa.table(
+        {
+            "link_id": pa.array(link_ids, type=links_arrow.column("link_id").type),
+            "geometry_wkt": pa.array(geom_wkts, type=pa.string()),
+            "source": pa.array(sources, type=pa.string()),
+        }
+    )
+
+
+def _build_geometry_lookup(net: Network) -> dict:
+    """Build ``{geometry_id: wkt}`` from ``net.geometry`` or return ``{}``."""
+    geom_table = net.geometry
+    if geom_table is None:
+        return {}
+    arrow = _to_arrow(geom_table)
+    ids = arrow.column("geometry_id").to_pylist()
+    wkts = arrow.column("geometry").to_pylist()
+    # Drop rows with missing keys; downstream code already handles missing lookups.
+    return {gid: wkt for gid, wkt in zip(ids, wkts, strict=True) if gid is not None and wkt is not None}
+
+
+def _build_node_xy_lookup(net: Network) -> dict:
+    """Build ``{node_id: (x_coord, y_coord)}`` from ``net.nodes``."""
+    arrow = _to_arrow(net.nodes)
+    ids = arrow.column("node_id").to_pylist()
+    xs = arrow.column("x_coord").to_pylist() if "x_coord" in arrow.column_names else [None] * len(ids)
+    ys = arrow.column("y_coord").to_pylist() if "y_coord" in arrow.column_names else [None] * len(ids)
+    return {nid: (x, y) for nid, x, y in zip(ids, xs, ys, strict=True) if nid is not None}
+
+
+def _to_arrow(table) -> pa.Table:
+    """Materialise a :class:`~datagrove.dataset.Table` to pyarrow.
+
+    Two-hop ``to_pandas`` → ``pa.Table.from_pandas`` matches the rest
+    of the gmnspy.indexes / semantics layer so we don't introduce a
+    second materialisation contract.
+    """
+    return pa.Table.from_pandas(table.to_pandas(), preserve_index=False)

--- a/packages/gmnspy/gmnspy/semantics/tod.py
+++ b/packages/gmnspy/gmnspy/semantics/tod.py
@@ -1,0 +1,172 @@
+"""Time-of-day (TOD) resolution for GMNS link / lane / segment tables.
+
+GMNS TOD tables (``link_tod``, ``lane_tod``, ``segment_tod``,
+``segment_lane_tod``, ``movement_tod``) carry per-time-period
+overrides keyed by ``time_set_definitions.timeday_id``. For example, a
+link's ``capacity`` may be 1800 by default but drop to 1500 during
+weekday AM peak via a ``link_tod`` row with ``timeday_id =
+"weekday_am_peak"`` and ``capacity = 1500``.
+
+:func:`resolve_link_attrs_at` returns the link table with any matching
+TOD overrides applied for the given ``time_set_id``.
+:func:`tod_coverage` reports which time periods have data on each TOD
+table — useful for auditing a fixture before running a TOD-aware op.
+
+Like :mod:`gmnspy.semantics.geometry`, this materialises through
+pyarrow rather than expressing the overlay in ibis. TOD tables are
+typically small (10s to 1000s of rows per period) so the round-trip is
+cheap, and the resulting code reads as a single top-to-bottom loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gmnspy.network import Network
+
+__all__ = ["resolve_link_attrs_at", "tod_coverage"]
+
+# Resource names of GMNS TOD tables, ordered roughly by usage frequency.
+# Each is the GMNS resource name (NOT the Network attribute); we look
+# them up by name via Package.tables[...] so attribute renames don't
+# silently break TOD coverage.
+_TOD_RESOURCES: tuple[str, ...] = (
+    "link_tod",
+    "lane_tod",
+    "segment_tod",
+    "segment_lane_tod",
+    "movement_tod",
+)
+
+
+def resolve_link_attrs_at(net: Network, time_set_id: str | int | None = None) -> pa.Table:
+    """Return the link table with TOD overrides applied for ``time_set_id``.
+
+    Args:
+        net: A loaded :class:`gmnspy.Network`.
+        time_set_id: The ``timeday_id`` to look up in ``link_tod``.
+            ``None`` returns the base link table unmodified.
+
+    Returns:
+        A :class:`pyarrow.Table` with the same columns as ``net.links``.
+        Where a ``link_tod`` row exists for the given ``time_set_id``
+        and a column, the override value replaces the base value;
+        otherwise the base value passes through.
+
+    The returned table is always materialised — callers downstream of
+    TOD resolution typically need to consume the values immediately
+    (e.g. for assignment, scoring, or report rendering).
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> from gmnspy.semantics import resolve_link_attrs_at
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> base = resolve_link_attrs_at(net, None)
+        >>> base.column_names == [c for c in net.links.columns()]
+        True
+    """
+    base = _to_arrow(net.links)
+    if time_set_id is None or net.link_tod is None:
+        return base
+
+    tod = _to_arrow(net.link_tod)
+    if "timeday_id" not in tod.column_names:
+        return base
+
+    # Filter TOD rows to the requested time period; keep only columns
+    # that exist on the base link table (TOD tables otherwise carry
+    # extra metadata like the TOD primary key).
+    tod_rows = _filter_by(tod, "timeday_id", time_set_id)
+    if tod_rows.num_rows == 0:
+        return base
+
+    overrides_by_link: dict = {}
+    tod_link_ids = tod_rows.column("link_id").to_pylist()
+    overridable_cols = [c for c in tod_rows.column_names if c in base.column_names and c != "link_id"]
+    col_values = {c: tod_rows.column(c).to_pylist() for c in overridable_cols}
+
+    for i, link_id in enumerate(tod_link_ids):
+        if link_id is None:
+            continue
+        # Last-writer-wins per link if the TOD table has dupes — log
+        # would be noise; the spec disallows duplicates per (link_id,
+        # timeday_id) so this is a defensive choice.
+        per_link = overrides_by_link.setdefault(link_id, {})
+        for col in overridable_cols:
+            val = col_values[col][i]
+            if val is not None:
+                per_link[col] = val
+
+    if not overrides_by_link:
+        return base
+
+    # Apply overrides column by column. We pylist + rebuild rather than
+    # in-place pyarrow mutation (which isn't supported) — the cost is
+    # one O(rows) pass per overridden column.
+    base_link_ids = base.column("link_id").to_pylist()
+    out_columns: dict[str, pa.Array] = {}
+    for col_name in base.column_names:
+        base_values = base.column(col_name).to_pylist()
+        if col_name in overridable_cols:
+            for i, lid in enumerate(base_link_ids):
+                ov = overrides_by_link.get(lid, {}).get(col_name)
+                if ov is not None:
+                    base_values[i] = ov
+        out_columns[col_name] = pa.array(base_values, type=base.column(col_name).type)
+
+    return pa.table(out_columns)
+
+
+def tod_coverage(net: Network) -> dict[str, list]:
+    """Return ``{tod_table_name: [timeday_ids present]}`` for each TOD table.
+
+    Useful for auditing: ``tod_coverage(net)["link_tod"]`` tells you
+    which periods have ``link_tod`` overrides at all, which is the
+    first thing you check before calling :func:`resolve_link_attrs_at`
+    in a loop over time periods.
+
+    Tables without a ``timeday_id`` column (or absent entirely) are
+    omitted from the result. Empty TOD tables map to an empty list.
+
+    Examples:
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> from gmnspy.semantics import tod_coverage
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> coverage = tod_coverage(net)
+        >>> "link_tod" in coverage  # Leavenworth has one link_tod row.
+        True
+    """
+    out: dict[str, list] = {}
+    for resource_name in _TOD_RESOURCES:
+        table = net.tables.get(resource_name)
+        if table is None:
+            continue
+        arrow = _to_arrow(table)
+        if "timeday_id" not in arrow.column_names:
+            continue
+        # Stable order (sorted) so doctests + snapshot tests are stable.
+        ids = sorted({i for i in arrow.column("timeday_id").to_pylist() if i is not None})
+        out[resource_name] = ids
+    return out
+
+
+def _filter_by(arrow: pa.Table, column: str, value) -> pa.Table:
+    """Return rows where ``arrow[column] == value``.
+
+    Mini helper kept inline (rather than imported from a util module)
+    so the TOD overlay code reads top-to-bottom in one file.
+    """
+    mask = pa.compute.equal(arrow.column(column), pa.scalar(value, type=arrow.column(column).type))
+    return arrow.filter(mask)
+
+
+def _to_arrow(table) -> pa.Table:
+    """Materialise a :class:`~datagrove.dataset.Table` to pyarrow."""
+    return pa.Table.from_pandas(table.to_pandas(), preserve_index=False)

--- a/packages/gmnspy/tests/test_semantics.py
+++ b/packages/gmnspy/tests/test_semantics.py
@@ -1,0 +1,335 @@
+"""Tests for :mod:`gmnspy.semantics` (task 3.8 / issue #76).
+
+Covers:
+
+* :mod:`gmnspy.semantics.connectivity` — :func:`is_connected`,
+  :func:`connected_components`, :func:`largest_component`,
+  :func:`unreachable_from`. Mix of Leavenworth (integration) +
+  hand-built micro networks (disconnect edge cases).
+* :mod:`gmnspy.semantics.geometry` — :func:`assemble_link_geometry`
+  exercises all three resolution paths (inline / geometry_id /
+  node_endpoints) via a hand-built fixture.
+* :mod:`gmnspy.semantics.tod` — :func:`resolve_link_attrs_at` flows
+  ``link_tod`` overrides onto the base link table;
+  :func:`tod_coverage` reports present periods. Leavenworth has one
+  ``link_tod`` row so it serves as the smoke test.
+"""
+
+from __future__ import annotations
+
+import pytest
+from datagrove.dataset import Table
+from datagrove.engines.pandas_engine import PandasEngine
+from datagrove.spec import DataPackage, Resource
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+# Local import of igraph + shapely guard happens inside the connectivity
+# helpers; the tests skip if igraph isn't installed (clean extra).
+pytest.importorskip("igraph")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _engine() -> PandasEngine:
+    """One engine for the semantics tests — backend-agnostic by design.
+
+    Connectivity / geometry / TOD all materialise through pyarrow, so
+    the engine choice doesn't change behaviour. PandasEngine is the
+    fastest setup for tiny networks.
+    """
+    return PandasEngine()
+
+
+def _network_from_tables(tables_dict: dict[str, Table], spec_version: str = "0.97") -> Network:
+    """Build a :class:`Network` from in-memory tables for tests.
+
+    Uses :meth:`Package.from_tables` under the hood but stamps the
+    ``spec_version`` so accessor error messages remain accurate.
+    """
+    engine = next(iter(tables_dict.values())).engine
+    spec = DataPackage(name="synthesized", resources=[Resource(name=n) for n in tables_dict])
+    return Network(
+        spec=spec,
+        tables=dict(tables_dict),
+        engine=engine,
+        spec_version=spec_version,
+    )
+
+
+def _link_table(engine, rows: list[dict]) -> Table:
+    """Build a :class:`Table` named ``link`` from row dicts."""
+    return Table(name="link", expr=engine.from_records(rows), engine=engine)
+
+
+def _node_table(engine, rows: list[dict]) -> Table:
+    """Build a :class:`Table` named ``node`` from row dicts."""
+    return Table(name="node", expr=engine.from_records(rows), engine=engine)
+
+
+# ---------------------------------------------------------------------------
+# Connectivity
+# ---------------------------------------------------------------------------
+
+
+def test_leavenworth_is_connected():
+    """Leavenworth fixture should be one weakly-connected component."""
+    from gmnspy.semantics import connected_components, is_connected
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    assert is_connected(net) is True
+    comps = connected_components(net)
+    assert len(comps) == 1
+
+
+def test_disconnected_network_has_two_components():
+    """Two clusters of nodes with no link between them -> 2 components."""
+    from gmnspy.semantics import connected_components, is_connected, largest_component
+
+    engine = _engine()
+    nodes = _node_table(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 1.0, "y_coord": 0.0},
+            {"node_id": 3, "x_coord": 10.0, "y_coord": 10.0},
+            {"node_id": 4, "x_coord": 11.0, "y_coord": 10.0},
+            {"node_id": 5, "x_coord": 12.0, "y_coord": 10.0},
+        ],
+    )
+    links = _link_table(
+        engine,
+        [
+            {"link_id": 1, "from_node_id": 1, "to_node_id": 2, "length": 1.0, "directed": False},
+            {"link_id": 2, "from_node_id": 3, "to_node_id": 4, "length": 1.0, "directed": False},
+            {"link_id": 3, "from_node_id": 4, "to_node_id": 5, "length": 1.0, "directed": False},
+        ],
+    )
+    net = _network_from_tables({"link": links, "node": nodes})
+
+    assert is_connected(net) is False
+    comps = connected_components(net)
+    assert len(comps) == 2
+    # Largest-first ordering invariant.
+    assert len(comps[0]) >= len(comps[1])
+    assert largest_component(net) == {3, 4, 5}
+
+
+def test_connectivity_caches_graph_index_on_network():
+    """First call builds + caches; second call reuses the cached index."""
+    from gmnspy.semantics.connectivity import _GRAPH_INDEX_KEY, connected_components
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    assert _GRAPH_INDEX_KEY not in net.metadata
+    connected_components(net)
+    assert _GRAPH_INDEX_KEY in net.metadata
+    cached_first = net.metadata[_GRAPH_INDEX_KEY]
+    connected_components(net)
+    assert net.metadata[_GRAPH_INDEX_KEY] is cached_first
+
+
+def test_unreachable_from_raises_on_unknown_seed():
+    """Unknown source_node_id -> SemanticsError mentioning the id + count."""
+    from gmnspy.semantics import SemanticsError, unreachable_from
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    with pytest.raises(SemanticsError, match="99999"):
+        unreachable_from(net, 99999)
+
+
+def test_unreachable_from_returns_set():
+    """Smoke: leavenworth is bidirectional so the unreachable set may be empty,
+    but the function must always return a set type."""
+    from gmnspy.semantics import largest_component, unreachable_from
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    seed = next(iter(largest_component(net)))
+    result = unreachable_from(net, seed)
+    assert isinstance(result, set)
+
+
+# ---------------------------------------------------------------------------
+# Geometry assembly
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_geometry_inline_wins():
+    """A link with inline geometry resolves as ``source = "inline"``."""
+    from gmnspy.semantics import assemble_link_geometry
+
+    engine = _engine()
+    nodes = _node_table(
+        engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}, {"node_id": 2, "x_coord": 1.0, "y_coord": 1.0}]
+    )
+    links = _link_table(
+        engine,
+        [
+            {
+                "link_id": 1,
+                "from_node_id": 1,
+                "to_node_id": 2,
+                "geometry": "LINESTRING (0 0, 0.5 0.5, 1 1)",
+                "geometry_id": None,
+            }
+        ],
+    )
+    net = _network_from_tables({"link": links, "node": nodes})
+    tbl = assemble_link_geometry(net)
+    assert tbl.column("source").to_pylist() == ["inline"]
+    assert "LINESTRING (0 0" in tbl.column("geometry_wkt").to_pylist()[0]
+
+
+def test_assemble_geometry_id_lookup():
+    """A link with geometry_id but no inline geometry resolves via geometry table."""
+    from gmnspy.semantics import assemble_link_geometry
+
+    engine = _engine()
+    nodes = _node_table(
+        engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}, {"node_id": 2, "x_coord": 2.0, "y_coord": 2.0}]
+    )
+    links = _link_table(
+        engine,
+        [
+            {
+                "link_id": 1,
+                "from_node_id": 1,
+                "to_node_id": 2,
+                "geometry": None,
+                "geometry_id": 42,
+            }
+        ],
+    )
+    geometry = Table(
+        name="geometry",
+        expr=engine.from_records([{"geometry_id": 42, "geometry": "LINESTRING (0 0, 1 1, 2 2)"}]),
+        engine=engine,
+    )
+    net = _network_from_tables({"link": links, "node": nodes, "geometry": geometry})
+    tbl = assemble_link_geometry(net)
+    assert tbl.column("source").to_pylist() == ["geometry_table"]
+    assert tbl.column("geometry_wkt").to_pylist() == ["LINESTRING (0 0, 1 1, 2 2)"]
+
+
+def test_assemble_geometry_falls_back_to_node_endpoints():
+    """No inline + no geometry_id resolution => synthesised LINESTRING."""
+    from gmnspy.semantics import assemble_link_geometry
+
+    engine = _engine()
+    nodes = _node_table(
+        engine, [{"node_id": 1, "x_coord": 0.5, "y_coord": 0.25}, {"node_id": 2, "x_coord": 3.5, "y_coord": 4.75}]
+    )
+    links = _link_table(
+        engine,
+        [
+            {
+                "link_id": 1,
+                "from_node_id": 1,
+                "to_node_id": 2,
+                "geometry": None,
+                "geometry_id": None,
+            }
+        ],
+    )
+    net = _network_from_tables({"link": links, "node": nodes})
+    tbl = assemble_link_geometry(net)
+    assert tbl.column("source").to_pylist() == ["node_endpoints"]
+    # Use 'in' to be tolerant of formatter trailing zeros / int coercion.
+    wkt = tbl.column("geometry_wkt").to_pylist()[0]
+    assert wkt.startswith("LINESTRING (")
+    assert "0.5" in wkt and "0.25" in wkt and "3.5" in wkt and "4.75" in wkt
+
+
+def test_assemble_geometry_leavenworth_uses_geometry_table():
+    """Leavenworth links carry geometry_id => all rows resolve via geometry_table."""
+    from gmnspy.semantics import assemble_link_geometry
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    tbl = assemble_link_geometry(net)
+    sources = set(tbl.column("source").to_pylist())
+    # Every Leavenworth link carries a geometry_id with a matching row.
+    assert sources == {"geometry_table"}
+
+
+# ---------------------------------------------------------------------------
+# TOD resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_tod_none_returns_base():
+    """``time_set_id=None`` returns the link table unchanged."""
+    from gmnspy.semantics import resolve_link_attrs_at
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    base = resolve_link_attrs_at(net, None)
+    # Same column set as the source link table.
+    assert set(base.column_names) == set(net.links.columns())
+
+
+def test_resolve_tod_applies_override():
+    """A TOD row for the target time_set_id replaces the base value on the affected column."""
+    from gmnspy.semantics import resolve_link_attrs_at
+
+    engine = _engine()
+    nodes = _node_table(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link_table(
+        engine,
+        [
+            {
+                "link_id": 1,
+                "from_node_id": 1,
+                "to_node_id": 1,
+                "capacity": 1800.0,
+                "free_speed": 60.0,
+            }
+        ],
+    )
+    link_tod = Table(
+        name="link_tod",
+        expr=engine.from_records(
+            [
+                {
+                    "link_tod_id": 100,
+                    "link_id": 1,
+                    "timeday_id": "am_peak",
+                    "capacity": 1500.0,
+                    # free_speed unset -> base value passes through.
+                }
+            ]
+        ),
+        engine=engine,
+    )
+    net = _network_from_tables({"link": links, "node": nodes, "link_tod": link_tod})
+
+    resolved = resolve_link_attrs_at(net, "am_peak")
+    row = resolved.to_pylist()[0]
+    assert row["capacity"] == 1500.0  # overridden
+    assert row["free_speed"] == 60.0  # passed through
+
+    # Off-peak (no matching TOD row) => base table.
+    off_peak = resolve_link_attrs_at(net, "pm_peak")
+    assert off_peak.to_pylist()[0]["capacity"] == 1800.0
+
+
+def test_tod_coverage_reports_link_tod_periods():
+    """:func:`tod_coverage` lists timeday_ids present per TOD table."""
+    from gmnspy.semantics import tod_coverage
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    coverage = tod_coverage(net)
+    # Leavenworth has one link_tod row with timeday_id="weekday_am_peak".
+    assert "link_tod" in coverage
+    assert coverage["link_tod"] == ["weekday_am_peak"]
+
+
+def test_tod_coverage_omits_absent_tables():
+    """No TOD tables loaded => empty coverage dict (not KeyError)."""
+    from gmnspy.semantics import tod_coverage
+
+    engine = _engine()
+    nodes = _node_table(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link_table(engine, [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "length": 0.0}])
+    net = _network_from_tables({"link": links, "node": nodes})
+    assert tod_coverage(net) == {}


### PR DESCRIPTION
## Summary

Implements **task 3.8** — GMNS-domain semantics on top of the Network + GraphIndex foundation merged in Phase 3 batch 2. Closes #76.

Three loosely-coupled submodules under `packages/gmnspy/gmnspy/semantics/`:

- **`connectivity.py`** — `is_connected`, `connected_components` (largest-first), `largest_component`, `unreachable_from` (directed traversal). Built on `gmnspy.indexes.GraphIndex`. The built index is cached on `Network.metadata` under `_GRAPH_INDEX_KEY` so repeat calls don't rebuild; **task 3.10 (scope) is expected to reuse the same cache key.**
- **`geometry.py`** — `assemble_link_geometry(net)` returns a pyarrow Table of `(link_id, geometry_wkt, source)` resolving inline `link.geometry` → `link.geometry_id` table lookup → straight-line fallback from node endpoints, stamping `source` for audit.
- **`tod.py`** — `resolve_link_attrs_at(net, time_set_id)` overlays `link_tod` overrides onto the base link table; `tod_coverage(net)` reports which `timeday_id`s are present per TOD table.

### Design call

All three modules materialise through pyarrow (consistent with `gmnspy.indexes`'s `_to_arrow` helper) instead of expressing the resolution chain in ibis. **Reason:** keeps each module readable top-to-bottom for the transportation-engineer audience that the project's legibility priority (Lens C) targets, and works across all engine backends (pandas / ibis / polars) without engine-specific branches. Materialisation cost is bounded — link tables are typically small in the contexts these helpers run in (validation, scoping, TOD-aware computation).

## Test plan

- [x] 13 new tests in `packages/gmnspy/tests/test_semantics.py` (connectivity on Leavenworth + hand-built disconnect, geometry's 3 resolution paths, TOD overlay + coverage).
- [x] 7 new doctests in the modules themselves.
- [x] Full suite: 661 → 693 passing.
- [x] `ruff check` / `ruff format --check` / `lint-imports` / `lint_no_sql.py` all clean.
- [x] No raw SQL introduced (lint enforced).

## Out of scope

- `link_centroid(net)` was in the original brief but deferred — requires shapely WKT parsing + centroid; can land as a follow-up issue if a Phase 4 consumer needs it.
- Network-aware scope ops (`from_nodes` BFS, `from_node` network buffer, etc.) live in **task 3.10** which will be the next PR in this batch; semantics.connectivity here provides the connected-component primitive that 3.10's `connected_component` scope reuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)