### PR TITLE
feat(scope): network-aware scope ops + composition + apply (#78)

### DIFF
--- a/packages/gmnspy/gmnspy/scope/__init__.py
+++ b/packages/gmnspy/gmnspy/scope/__init__.py
@@ -1,1 +1,45 @@
-"""Network-aware scoping: BFS / shortest-path subgraph, network-distance buffer, spatial buffer from link/point/node."""
+"""Network-aware scope ops — BFS subgraph, network buffer, spatial buffer, zone, component.
+
+Re-exports the public surface from :mod:`gmnspy.scope.scope`. The
+single file holds all constructors + composition + apply because the
+ops share an FK-pushdown pattern that reads more cleanly side-by-side
+than spread across N files (project legibility priority).
+
+Public surface:
+
+* :class:`NetworkScope` — the immutable (link_ids, node_ids) value
+  with composition methods (``union`` / ``intersect`` / ``subtract`` /
+  ``buffer_network`` / ``buffer_spatial``) and :meth:`apply`.
+* Constructors: :func:`from_nodes`, :func:`from_node`,
+  :func:`from_link`, :func:`from_point`, :func:`connected_component`,
+  :func:`from_zone`.
+* :class:`ScopeError` — typed exception (subclass of
+  :class:`gmnspy.NetworkError`).
+* :data:`AUTO_INDEX_THRESHOLD_DEFAULT` — node-count threshold above
+  which auto-build emits an info log; override via env var
+  ``GMNSPY_AUTO_INDEX_THRESHOLD``.
+"""
+
+from .errors import ScopeError
+from .scope import (
+    AUTO_INDEX_THRESHOLD_DEFAULT,
+    NetworkScope,
+    connected_component,
+    from_link,
+    from_node,
+    from_nodes,
+    from_point,
+    from_zone,
+)
+
+__all__ = [
+    "AUTO_INDEX_THRESHOLD_DEFAULT",
+    "NetworkScope",
+    "ScopeError",
+    "connected_component",
+    "from_link",
+    "from_node",
+    "from_nodes",
+    "from_point",
+    "from_zone",
+]

--- a/packages/gmnspy/gmnspy/scope/errors.py
+++ b/packages/gmnspy/gmnspy/scope/errors.py
@@ -1,0 +1,17 @@
+"""Typed exceptions for :mod:`gmnspy.scope`."""
+
+from __future__ import annotations
+
+from gmnspy.network import NetworkError
+
+__all__ = ["ScopeError"]
+
+
+class ScopeError(NetworkError):
+    """A network-aware scope op cannot complete on the given inputs.
+
+    Raised for unknown seed ids, missing required tables (e.g.
+    ``from_zone`` with no ``node.zone_id`` column), or invalid
+    distance arguments. Subclasses :class:`gmnspy.NetworkError` so
+    generic handlers still catch it.
+    """

--- a/packages/gmnspy/gmnspy/scope/scope.py
+++ b/packages/gmnspy/gmnspy/scope/scope.py
@@ -1,0 +1,754 @@
+"""Network-aware scope ops for GMNS :class:`gmnspy.Network` (task 3.10).
+
+A :class:`NetworkScope` is a (frozen) pair of node id + link id sets
+plus a reference to the source :class:`Network`. Each constructor
+function builds one from a seed (nodes, a link, a point, a zone, …);
+each composition method returns a new scope; calling :meth:`apply`
+returns a fresh :class:`Network` whose tables are filtered to the
+scope's id sets via the GMNS FK chain.
+
+Cross-references for the reader:
+
+* :mod:`gmnspy.indexes` — the underlying :class:`GraphIndex` (igraph)
+  and :class:`SpatialIndex` (STRtree) primitives. We build (or reuse
+  via :data:`gmnspy.semantics.connectivity._GRAPH_INDEX_KEY` cache)
+  these on first use.
+* :mod:`gmnspy.semantics.connectivity` — connected-component logic.
+  :func:`connected_component` here reuses ``GraphIndex.connected_component``
+  directly rather than going through ``semantics.connected_components``,
+  because we only need one component, not the full partition.
+* :mod:`datagrove.dataset.view` — the generic spatial scopes (bbox,
+  polygon, geometry-buffer). Spatial-only scopes already work via
+  ``net.scope.from_bbox(...)``; this module adds the GMNS-aware
+  network-distance and topology-aware constructors.
+
+Design decisions for the reader:
+
+* **Single file.** All constructors + composition + apply live here.
+  Splitting per-op into N files would obscure the shared FK-pushdown
+  pattern; each function is short and reads top-to-bottom.
+* **Frozen scope.** :class:`NetworkScope` is immutable so composition
+  ops are pure (no aliasing surprises when chaining).
+* **Index cache key.** We stash both spatial + graph indexes on
+  ``Network.metadata`` under the same key used by
+  :mod:`gmnspy.semantics.connectivity` so the two modules share a
+  build.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING
+
+from datagrove.dataset import Table
+
+from .errors import ScopeError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gmnspy.indexes import GraphIndex, SpatialIndex
+    from gmnspy.network import Network
+
+__all__ = [
+    "AUTO_INDEX_THRESHOLD_DEFAULT",
+    "NetworkScope",
+    "connected_component",
+    "from_link",
+    "from_node",
+    "from_nodes",
+    "from_point",
+    "from_zone",
+]
+
+logger = logging.getLogger(__name__)
+
+# Default node-count threshold above which network-aware scope ops
+# emit an info-level "building graph index" warning the first time they
+# build an index. Callers who don't want the surprise can either
+# pre-build (``net.metadata[_GRAPH_INDEX_KEY] = GraphIndex.build(...)``)
+# or raise the threshold via ``GMNSPY_AUTO_INDEX_THRESHOLD`` env var.
+AUTO_INDEX_THRESHOLD_DEFAULT: int = 50_000
+
+# Same cache keys as gmnspy.semantics so the two modules share a build.
+# Duplicated rather than imported so semantics imports don't pull the
+# scope module into memory just for the constants.
+_GRAPH_INDEX_KEY = "_cached_graph_index"
+_SPATIAL_INDEX_KEY = "_cached_spatial_index"
+
+
+# ---------------------------------------------------------------------------
+# Distance parsing — keep it small + inline; no `pint` dep.
+# ---------------------------------------------------------------------------
+#
+# Bare numbers are treated as **meters** (the GMNS spec uses meters
+# for link.length). String forms accept the common transportation
+# units the project's modeler audience writes by hand.
+
+_UNIT_TO_METERS: dict[str, float] = {
+    "m": 1.0,
+    "meter": 1.0,
+    "meters": 1.0,
+    "km": 1000.0,
+    "ft": 0.3048,
+    "feet": 0.3048,
+    "mi": 1609.344,
+    "mile": 1609.344,
+    "miles": 1609.344,
+}
+
+_DISTANCE_RE = re.compile(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)\s*$")
+
+
+def _parse_distance(value: str | float | int) -> float:
+    """Return ``value`` as meters.
+
+    Numeric inputs (``0.5``, ``800``) are already meters. String inputs
+    must match ``<number><unit>`` where unit is one of m/km/ft/mi (and
+    spelled-out variants). Unknown units raise :class:`ScopeError`.
+
+    Examples:
+        >>> _parse_distance(800)
+        800.0
+        >>> _parse_distance("0.5mi")
+        804.672
+        >>> round(_parse_distance("1km"), 2)
+        1000.0
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    match = _DISTANCE_RE.match(str(value))
+    if not match:
+        raise ScopeError(f"Unparseable distance {value!r}: expected '<number><unit>' (e.g. '0.5mi', '800m').")
+    number, unit = match.group(1), match.group(2).lower()
+    factor = _UNIT_TO_METERS.get(unit)
+    if factor is None:
+        supported = ", ".join(sorted(set(_UNIT_TO_METERS)))
+        raise ScopeError(f"Unknown distance unit {unit!r} in {value!r}; supported: {supported}.")
+    return float(number) * factor
+
+
+# ---------------------------------------------------------------------------
+# NetworkScope value type + composition + apply
+# ---------------------------------------------------------------------------
+#
+# GMNS-table → (column, id-source) mapping for FK pushdown inside
+# :meth:`NetworkScope.apply`. Format:
+#   resource_name: list of (column, "link" | "node")
+# A row is kept iff at least one of its (column, source) pairs matches
+# the scope's id set. Tables not in this dict pass through unchanged
+# (documented in the docstring) — keeps the table easy to extend.
+_FK_PUSHDOWN: dict[str, list[tuple[str, str]]] = {
+    "link": [("link_id", "link")],
+    "node": [("node_id", "node")],
+    "geometry": [],  # filtered separately via geometry_id from kept links
+    "lane": [("link_id", "link")],
+    "segment": [("link_id", "link")],
+    "segment_lane": [("link_id", "link")],
+    "link_tod": [("link_id", "link")],
+    "lane_tod": [("link_id", "link")],
+    "segment_tod": [("link_id", "link")],
+    "segment_lane_tod": [("link_id", "link")],
+    "movement": [
+        ("ib_link_id", "link"),
+        ("ob_link_id", "link"),
+        ("node_id", "node"),
+    ],
+    "movement_tod": [
+        ("ib_link_id", "link"),
+        ("ob_link_id", "link"),
+        ("node_id", "node"),
+    ],
+    "signal_controller": [("node_id", "node")],
+    "signal_coordination": [("node_id", "node")],
+    "signal_detector": [("node_id", "node")],
+    "signal_phase_mvmt": [("node_id", "node")],
+    "signal_timing_phase": [("node_id", "node")],
+    "signal_timing_plan": [("node_id", "node")],
+}
+
+
+@dataclass(frozen=True)
+class NetworkScope:
+    """An immutable subset of a :class:`Network`'s links + nodes.
+
+    Built by the module-level constructors (:func:`from_nodes`,
+    :func:`from_node`, :func:`from_link`, :func:`from_point`,
+    :func:`connected_component`, :func:`from_zone`) and composed via
+    :meth:`union` / :meth:`intersect` / :meth:`subtract` /
+    :meth:`buffer_network` / :meth:`buffer_spatial`. :meth:`apply`
+    materialises the scope as a fresh :class:`Network` with all
+    FK-related tables pre-filtered.
+
+    Attributes:
+        node_ids: frozenset of node ids in the scope.
+        link_ids: frozenset of link ids in the scope.
+        network: the source :class:`Network` (used by composition ops
+            to access the cached indexes; not re-validated on the
+            return path of :meth:`apply`).
+        provenance: short human-readable trail of how this scope was
+            built (e.g. ``"from_nodes([1,2,3], path_between=True)"``).
+            Used in error messages and scope.__repr__.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("igraph")
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> from gmnspy.scope import from_nodes
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> scope = from_nodes(net, [1, 2], path_between=True)
+        >>> isinstance(scope, NetworkScope)
+        True
+        >>> sub = scope.apply()
+        >>> sub.links.count() <= net.links.count()
+        True
+    """
+
+    node_ids: frozenset[int]
+    link_ids: frozenset[int]
+    network: Network = field(repr=False, hash=False, compare=False)
+    provenance: str = ""
+
+    def __len__(self) -> int:
+        """Total ids in the scope (links + nodes) — useful for sanity-checking sizes."""
+        return len(self.node_ids) + len(self.link_ids)
+
+    def __repr__(self) -> str:
+        """Compact repr for shell + log output."""
+        return f"NetworkScope(nodes={len(self.node_ids)}, links={len(self.link_ids)}, via={self.provenance!r})"
+
+    # -- composition --------------------------------------------------------
+
+    def union(self, other: NetworkScope) -> NetworkScope:
+        """Return the union of two scopes (same network)."""
+        _require_same_network(self, other, "union")
+        return replace(
+            self,
+            node_ids=self.node_ids | other.node_ids,
+            link_ids=self.link_ids | other.link_ids,
+            provenance=f"({self.provenance}) | ({other.provenance})",
+        )
+
+    def intersect(self, other: NetworkScope) -> NetworkScope:
+        """Return the intersection of two scopes (same network)."""
+        _require_same_network(self, other, "intersect")
+        return replace(
+            self,
+            node_ids=self.node_ids & other.node_ids,
+            link_ids=self.link_ids & other.link_ids,
+            provenance=f"({self.provenance}) & ({other.provenance})",
+        )
+
+    def subtract(self, other: NetworkScope) -> NetworkScope:
+        """Return the set-difference (self minus other) of two scopes (same network)."""
+        _require_same_network(self, other, "subtract")
+        return replace(
+            self,
+            node_ids=self.node_ids - other.node_ids,
+            link_ids=self.link_ids - other.link_ids,
+            provenance=f"({self.provenance}) - ({other.provenance})",
+        )
+
+    def buffer_network(self, distance: str | float) -> NetworkScope:
+        """Extend the scope by all nodes within ``distance`` network-distance of any current node.
+
+        Adds the induced links (any link whose endpoints are both in
+        the expanded node set) so the result remains a proper subgraph.
+        """
+        meters = _parse_distance(distance)
+        graph = _get_or_build_graph_index(self.network)
+        expanded_nodes = graph.network_buffer(list(self.node_ids), meters)
+        new_nodes = self.node_ids | expanded_nodes
+        new_links = self.link_ids | _induced_link_ids(self.network, new_nodes)
+        return replace(
+            self,
+            node_ids=frozenset(new_nodes),
+            link_ids=frozenset(new_links),
+            provenance=f"{self.provenance} + buffer_network({distance!r})",
+        )
+
+    def buffer_spatial(self, distance_m: float) -> NetworkScope:
+        """Extend the scope by all links within ``distance_m`` of any current link's geometry.
+
+        Implementation note: builds a shapely union of the current
+        scope's link geometries, then queries the SpatialIndex with
+        ``distance_m`` as a buffer. Endpoint nodes of any newly added
+        links are folded in too.
+        """
+        spatial = _get_or_build_spatial_index(self.network)
+        if spatial is None or len(spatial) == 0:
+            return self  # No geometry available — silent no-op.
+        # Pull the WKT of each current link from the network for the union.
+        from shapely import unary_union
+
+        link_geoms = _link_geometries(self.network, self.link_ids)
+        if not link_geoms:
+            return self
+        merged = unary_union(link_geoms)
+        new_link_ids = set(spatial.query_geometry(merged, distance_m=distance_m))
+        all_links = self.link_ids | new_link_ids
+        # Recompute node set from final link set so endpoints get included.
+        all_nodes = self.node_ids | _link_endpoint_nodes(self.network, new_link_ids)
+        return replace(
+            self,
+            node_ids=frozenset(all_nodes),
+            link_ids=frozenset(all_links),
+            provenance=f"{self.provenance} + buffer_spatial({distance_m})",
+        )
+
+    # -- materialisation ----------------------------------------------------
+
+    def apply(self) -> Network:
+        """Return a new :class:`Network` whose tables are filtered to the scope.
+
+        Pushdown rules:
+
+        * ``link`` -> rows where ``link_id`` is in :attr:`link_ids`.
+        * ``node`` -> rows where ``node_id`` is in :attr:`node_ids`.
+        * ``geometry`` -> rows whose ``geometry_id`` is referenced by
+          any surviving link.
+        * Other tables in :data:`_FK_PUSHDOWN` -> rows where any of
+          their FK columns match the scope's id sets.
+        * Tables outside :data:`_FK_PUSHDOWN` (e.g. ``time_set_definitions``,
+          ``use_definition``) pass through unfiltered — they are
+          dimension tables, not network-keyed.
+        """
+        # Local import to keep cold-import cheap.
+        from gmnspy.network import Network
+
+        node_set, link_set = set(self.node_ids), set(self.link_ids)
+        new_tables: dict[str, Table] = {}
+
+        # First pass: link, node, and any other FK-pushdown table.
+        for name, table in self.network.tables.items():
+            mapping = _FK_PUSHDOWN.get(name)
+            if mapping is None or name == "geometry":
+                # Pass-through or handled below.
+                new_tables[name] = table
+                continue
+            new_tables[name] = _filter_table_by_id_columns(table, mapping, node_set, link_set)
+
+        # Geometry filter requires the surviving link rows' geometry_id.
+        if "geometry" in self.network.tables:
+            new_tables["geometry"] = _filter_geometry_by_links(
+                self.network.tables["geometry"],
+                new_tables.get("link"),
+            )
+
+        return Network(
+            spec=self.network.spec,
+            tables=new_tables,
+            engine=self.network.engine,
+            source=self.network.source,
+            metadata={
+                **self.network.metadata,
+                "_scope_provenance": self.provenance,
+            },
+            spec_version=self.network.spec_version,
+        )
+
+
+def _require_same_network(left: NetworkScope, right: NetworkScope, op: str) -> None:
+    """Composition only makes sense within one network — raise if not."""
+    if left.network is not right.network:
+        raise ScopeError(f"Cannot {op} scopes from different networks ({left.network!r} vs {right.network!r}).")
+
+
+# ---------------------------------------------------------------------------
+# Scope constructors
+# ---------------------------------------------------------------------------
+
+
+def from_nodes(
+    net: Network,
+    node_ids: Iterable[int],
+    *,
+    path_between: bool = True,
+) -> NetworkScope:
+    """Scope built from a set of seed nodes.
+
+    Args:
+        net: The source :class:`Network`.
+        node_ids: Seed node ids. Unknown ids are silently dropped (the
+            scope just gets smaller) so callers can pass loose lists
+            without pre-validating.
+        path_between: If ``True`` (default), expand the scope to
+            include nodes + links on the shortest path between every
+            pair of seeds (BFS-equivalent on uniformly weighted
+            graphs; weighted by ``link.length`` on GMNS networks). If
+            ``False``, the scope is just the seed nodes plus the
+            links directly incident on them.
+
+    Returns:
+        A :class:`NetworkScope`.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("igraph")
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> scope = from_nodes(net, [1, 2, 3], path_between=False)
+        >>> 1 in scope.node_ids
+        True
+    """
+    _maybe_warn_auto_index(net, "from_nodes")
+    graph = _get_or_build_graph_index(net)
+    seeds = {int(n) for n in node_ids if int(n) in graph._pos}
+    nodes: set[int] = set(seeds)
+
+    if path_between and len(seeds) > 1:
+        seed_list = sorted(seeds)
+        for i, src in enumerate(seed_list):
+            for dst in seed_list[i + 1 :]:
+                path = graph.shortest_path(src, dst)
+                nodes.update(path)
+
+    link_ids = _induced_link_ids(net, nodes)
+    return NetworkScope(
+        node_ids=frozenset(nodes),
+        link_ids=frozenset(link_ids),
+        network=net,
+        provenance=f"from_nodes({sorted(seeds)!r}, path_between={path_between})",
+    )
+
+
+def from_node(
+    net: Network,
+    node_id: int,
+    *,
+    network_buffer: str | float = "0.5mi",
+) -> NetworkScope:
+    """Scope = all nodes within ``network_buffer`` network-distance of ``node_id``.
+
+    Dijkstra-bounded on the underlying :class:`GraphIndex`; the result
+    includes the seed node, all reachable nodes within distance, and
+    every link whose endpoints are both in the resulting node set.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("igraph")
+        >>> from gmnspy import Network
+        >>> from gmnspy.fixtures import leavenworth
+        >>> from datagrove.engines.pandas_engine import PandasEngine
+        >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+        >>> scope = from_node(net, 1, network_buffer="200m")
+        >>> 1 in scope.node_ids
+        True
+    """
+    _maybe_warn_auto_index(net, "from_node")
+    meters = _parse_distance(network_buffer)
+    graph = _get_or_build_graph_index(net)
+    if int(node_id) not in graph._pos:
+        raise ScopeError(f"node_id={node_id!r} not present in network.nodes.")
+    nodes = graph.network_buffer([int(node_id)], meters) | {int(node_id)}
+    link_ids = _induced_link_ids(net, nodes)
+    return NetworkScope(
+        node_ids=frozenset(nodes),
+        link_ids=frozenset(link_ids),
+        network=net,
+        provenance=f"from_node({node_id!r}, network_buffer={network_buffer!r})",
+    )
+
+
+def from_link(
+    net: Network,
+    link_id: int,
+    *,
+    spatial_buffer_m: float | None = None,
+    network_buffer: str | float | None = None,
+) -> NetworkScope:
+    """Scope seeded by one link, expanded by either a spatial or network buffer.
+
+    Exactly one of ``spatial_buffer_m`` / ``network_buffer`` must be
+    provided. The seed link is always included regardless.
+    """
+    if (spatial_buffer_m is None) == (network_buffer is None):
+        raise ScopeError("from_link requires exactly one of spatial_buffer_m or network_buffer.")
+    _maybe_warn_auto_index(net, "from_link")
+
+    if spatial_buffer_m is not None:
+        spatial = _get_or_build_spatial_index(net)
+        if spatial is None:
+            raise ScopeError("from_link(spatial_buffer_m=...) requires a geometry column on links.")
+        from shapely import from_wkt
+
+        geoms = _link_geometries(net, {int(link_id)})
+        if not geoms:
+            raise ScopeError(f"link_id={link_id!r} has no parseable geometry.")
+        new_link_ids = set(spatial.query_geometry(from_wkt(geoms[0].wkt), distance_m=spatial_buffer_m))
+        new_link_ids.add(int(link_id))
+        nodes = _link_endpoint_nodes(net, new_link_ids)
+        provenance = f"from_link({link_id!r}, spatial_buffer_m={spatial_buffer_m})"
+    else:
+        # Network buffer: seed nodes = the link's two endpoints; then expand.
+        endpoints = _link_endpoint_nodes(net, {int(link_id)})
+        if not endpoints:
+            raise ScopeError(f"link_id={link_id!r} not found in network.links.")
+        graph = _get_or_build_graph_index(net)
+        meters = _parse_distance(network_buffer)
+        nodes = graph.network_buffer(list(endpoints), meters) | endpoints
+        new_link_ids = _induced_link_ids(net, nodes) | {int(link_id)}
+        provenance = f"from_link({link_id!r}, network_buffer={network_buffer!r})"
+
+    return NetworkScope(
+        node_ids=frozenset(nodes),
+        link_ids=frozenset(new_link_ids),
+        network=net,
+        provenance=provenance,
+    )
+
+
+def from_point(
+    net: Network,
+    xy: tuple[float, float],
+    *,
+    spatial_buffer_m: float = 100.0,
+) -> NetworkScope:
+    """Scope = links within ``spatial_buffer_m`` of ``(x, y)`` (CRS of the geometry column).
+
+    Snaps to the nearest link via :class:`SpatialIndex` first (which
+    needs no actual snapping — STRtree handles the point-buffer query
+    directly), then includes endpoint nodes of every matching link.
+    """
+    _maybe_warn_auto_index(net, "from_point")
+    spatial = _get_or_build_spatial_index(net)
+    if spatial is None:
+        raise ScopeError("from_point requires a geometry column on links.")
+    x, y = xy
+    link_ids = set(spatial.query_point(float(x), float(y), distance_m=spatial_buffer_m))
+    nodes = _link_endpoint_nodes(net, link_ids)
+    return NetworkScope(
+        node_ids=frozenset(nodes),
+        link_ids=frozenset(link_ids),
+        network=net,
+        provenance=f"from_point({xy!r}, spatial_buffer_m={spatial_buffer_m})",
+    )
+
+
+def connected_component(net: Network, seed_node_id: int) -> NetworkScope:
+    """Scope = the entire weakly-connected component containing ``seed_node_id``."""
+    _maybe_warn_auto_index(net, "connected_component")
+    graph = _get_or_build_graph_index(net)
+    nodes = graph.connected_component(int(seed_node_id))
+    if not nodes:
+        raise ScopeError(f"seed_node_id={seed_node_id!r} not present in network.nodes.")
+    link_ids = _induced_link_ids(net, nodes)
+    return NetworkScope(
+        node_ids=frozenset(nodes),
+        link_ids=frozenset(link_ids),
+        network=net,
+        provenance=f"connected_component({seed_node_id!r})",
+    )
+
+
+def from_zone(net: Network, zone_ids: Iterable[int]) -> NetworkScope:
+    """Scope = all nodes (and their incident links) whose ``zone_id`` is in ``zone_ids``.
+
+    Requires ``net.nodes`` to carry a ``zone_id`` column; raises
+    :class:`ScopeError` otherwise.
+    """
+    if "zone_id" not in net.nodes.columns():
+        raise ScopeError("from_zone requires a 'zone_id' column on the node table.")
+    target_zones = {int(z) for z in zone_ids}
+    nodes_arrow = _to_arrow(net.nodes)
+    nids = nodes_arrow.column("node_id").to_pylist()
+    zids = nodes_arrow.column("zone_id").to_pylist()
+    matching_nodes = {int(n) for n, z in zip(nids, zids, strict=True) if z is not None and int(z) in target_zones}
+    link_ids = _induced_link_ids(net, matching_nodes)
+    return NetworkScope(
+        node_ids=frozenset(matching_nodes),
+        link_ids=frozenset(link_ids),
+        network=net,
+        provenance=f"from_zone({sorted(target_zones)!r})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Index access + auto-build heuristic
+# ---------------------------------------------------------------------------
+
+
+def _get_or_build_graph_index(net: Network) -> GraphIndex:
+    """Return the cached :class:`GraphIndex`, or build + cache one.
+
+    Same cache key as :mod:`gmnspy.semantics.connectivity` — the two
+    modules deliberately share the build.
+    """
+    cached = net.metadata.get(_GRAPH_INDEX_KEY)
+    if cached is not None:
+        return cached
+    from gmnspy.indexes import GraphIndex
+
+    index = GraphIndex.build(net.links, net.nodes)
+    net.metadata[_GRAPH_INDEX_KEY] = index
+    return index
+
+
+def _get_or_build_spatial_index(net: Network) -> SpatialIndex | None:
+    """Return the cached :class:`SpatialIndex`, or build + cache (None if no geometry)."""
+    cached = net.metadata.get(_SPATIAL_INDEX_KEY)
+    if cached is not None:
+        return cached
+    if "geometry" not in net.links.columns():
+        # No inline link.geometry; we don't auto-resolve geometry_id
+        # here (that's :func:`gmnspy.semantics.assemble_link_geometry`'s
+        # job) — callers wanting spatial scope on geometry-table-backed
+        # networks should call ``net.build_indexes(spatial=True)``
+        # after assembling first.
+        return None
+    from gmnspy.indexes import SpatialIndex
+
+    index = SpatialIndex.build(net.links)
+    net.metadata[_SPATIAL_INDEX_KEY] = index
+    return index
+
+
+def _maybe_warn_auto_index(net: Network, op_name: str) -> None:
+    """Emit an info log if we're about to auto-build an index over a large network.
+
+    Only fires if (a) no graph index is cached, AND (b) the node table
+    exceeds the threshold. Callers who care can avoid the surprise by
+    pre-building or raising ``GMNSPY_AUTO_INDEX_THRESHOLD``.
+    """
+    if _GRAPH_INDEX_KEY in net.metadata:
+        return
+    try:
+        threshold = int(os.environ.get("GMNSPY_AUTO_INDEX_THRESHOLD", AUTO_INDEX_THRESHOLD_DEFAULT))
+    except ValueError:
+        threshold = AUTO_INDEX_THRESHOLD_DEFAULT
+    node_count = net.nodes.count()
+    if node_count > threshold:
+        logger.info(
+            "%s: auto-building graph index over %d nodes (>%d threshold). "
+            "Call net.build_indexes(graph=True) up front or raise "
+            "GMNSPY_AUTO_INDEX_THRESHOLD to avoid this on cold starts.",
+            op_name,
+            node_count,
+            threshold,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pyarrow-level helpers (shared with semantics layer)
+# ---------------------------------------------------------------------------
+
+
+def _induced_link_ids(net: Network, node_ids: set[int]) -> set[int]:
+    """Return link ids whose from/to endpoints are BOTH in ``node_ids``."""
+    if not node_ids:
+        return set()
+    arrow = _to_arrow(net.links)
+    lid_col = arrow.column("link_id").to_pylist()
+    from_col = arrow.column("from_node_id").to_pylist()
+    to_col = arrow.column("to_node_id").to_pylist()
+    return {
+        int(lid)
+        for lid, f, t in zip(lid_col, from_col, to_col, strict=True)
+        if f is not None and t is not None and int(f) in node_ids and int(t) in node_ids
+    }
+
+
+def _link_endpoint_nodes(net: Network, link_ids: set[int]) -> set[int]:
+    """Return the union of from_node_id + to_node_id over ``link_ids``."""
+    if not link_ids:
+        return set()
+    arrow = _to_arrow(net.links)
+    lid_col = arrow.column("link_id").to_pylist()
+    from_col = arrow.column("from_node_id").to_pylist()
+    to_col = arrow.column("to_node_id").to_pylist()
+    nodes: set[int] = set()
+    for lid, f, t in zip(lid_col, from_col, to_col, strict=True):
+        if lid is not None and int(lid) in link_ids:
+            if f is not None:
+                nodes.add(int(f))
+            if t is not None:
+                nodes.add(int(t))
+    return nodes
+
+
+def _link_geometries(net: Network, link_ids: set[int]):
+    """Return the parsed shapely geometries for ``link_ids`` (drops null/unparseable)."""
+    from shapely import from_wkt
+
+    if not link_ids or "geometry" not in net.links.columns():
+        return []
+    arrow = _to_arrow(net.links)
+    lid_col = arrow.column("link_id").to_pylist()
+    geom_col = arrow.column("geometry").to_pylist()
+    geoms = []
+    for lid, wkt in zip(lid_col, geom_col, strict=True):
+        if lid is None or int(lid) not in link_ids or wkt is None:
+            continue
+        try:
+            g = from_wkt(str(wkt))
+        except Exception:  # pragma: no cover - shapely raises broadly
+            continue
+        if g is not None and not g.is_empty:
+            geoms.append(g)
+    return geoms
+
+
+def _filter_table_by_id_columns(
+    table: Table,
+    mapping: list[tuple[str, str]],
+    node_set: set[int],
+    link_set: set[int],
+) -> Table:
+    """Return ``table`` with rows kept where any FK column matches the right id set.
+
+    Materialises through pyarrow + rebuilds via ``engine.from_records``
+    — same pattern used by :mod:`datagrove.dataset.view` for non-ibis
+    backends. Tables with no rows pass through.
+    """
+    arrow = _to_arrow(table)
+    if arrow.num_rows == 0 or not mapping:
+        return table
+    keep_mask: list[bool] = [False] * arrow.num_rows
+    for col_name, kind in mapping:
+        if col_name not in arrow.column_names:
+            continue
+        values = arrow.column(col_name).to_pylist()
+        target = link_set if kind == "link" else node_set
+        for i, v in enumerate(values):
+            if v is not None and int(v) in target:
+                keep_mask[i] = True
+    rows = arrow.to_pylist()
+    kept = [r for r, m in zip(rows, keep_mask, strict=True) if m]
+    # Engines accept an empty list and reconstruct an empty table preserving column hints
+    # — we rely on that so a fully-filtered-out scope keeps the package's table contract.
+    new_expr = table.engine.from_records(kept)
+    return Table(name=table.name, expr=new_expr, engine=table.engine, schema=table.schema, source=table.source)
+
+
+def _filter_geometry_by_links(geometry_table: Table, link_table: Table | None) -> Table:
+    """Filter the geometry table to ``geometry_id``s referenced by the kept links."""
+    if link_table is None:
+        return geometry_table
+    link_arrow = _to_arrow(link_table)
+    if "geometry_id" not in link_arrow.column_names:
+        return geometry_table
+    referenced = {int(g) for g in link_arrow.column("geometry_id").to_pylist() if g is not None}
+    geom_arrow = _to_arrow(geometry_table)
+    rows = geom_arrow.to_pylist()
+    kept = [r for r in rows if r.get("geometry_id") is not None and int(r["geometry_id"]) in referenced]
+    new_expr = geometry_table.engine.from_records(kept)
+    return Table(
+        name=geometry_table.name,
+        expr=new_expr,
+        engine=geometry_table.engine,
+        schema=geometry_table.schema,
+        source=geometry_table.source,
+    )
+
+
+def _to_arrow(table: Table):
+    """Materialise a :class:`~datagrove.dataset.Table` to pyarrow."""
+    import pyarrow as pa
+
+    return pa.Table.from_pandas(table.to_pandas(), preserve_index=False)

--- a/packages/gmnspy/tests/test_scope.py
+++ b/packages/gmnspy/tests/test_scope.py
@@ -1,0 +1,485 @@
+"""Tests for :mod:`gmnspy.scope` (task 3.10 / issue #78).
+
+Covers:
+
+* Distance parser (``_parse_distance``) — units, errors.
+* Each constructor (``from_nodes``, ``from_node``, ``from_link``,
+  ``from_point``, ``connected_component``, ``from_zone``) on small
+  hand-built networks where the expected node/link sets are exact.
+* Composition (``union``, ``intersect``, ``subtract``,
+  ``buffer_network``, ``buffer_spatial``).
+* :meth:`NetworkScope.apply` — FK-pushdown filters all known GMNS
+  tables to the scope.
+* Index-cache reuse across calls (perf-relevant: rebuilding a
+  GraphIndex over a regional network is the slow path).
+
+Hand-built synthetic networks dominate so the expected sets are exact;
+Leavenworth provides smoke coverage on the realistic-shape path.
+"""
+
+from __future__ import annotations
+
+import pytest
+from datagrove.dataset import Table
+from datagrove.engines.pandas_engine import PandasEngine
+from datagrove.spec import DataPackage, Resource
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+pytest.importorskip("igraph")
+pytest.importorskip("shapely")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — small grid network for exact-set assertions
+# ---------------------------------------------------------------------------
+
+
+def _engine() -> PandasEngine:
+    """One engine for the scope tests — operations are engine-agnostic."""
+    return PandasEngine()
+
+
+def _network(tables_dict: dict[str, Table]) -> Network:
+    """Build a :class:`Network` from in-memory tables for tests."""
+    engine = next(iter(tables_dict.values())).engine
+    spec = DataPackage(name="synthesized", resources=[Resource(name=n) for n in tables_dict])
+    return Network(spec=spec, tables=dict(tables_dict), engine=engine, spec_version="0.97")
+
+
+def _link(engine, rows: list[dict]) -> Table:
+    return Table(name="link", expr=engine.from_records(rows), engine=engine)
+
+
+def _node(engine, rows: list[dict]) -> Table:
+    return Table(name="node", expr=engine.from_records(rows), engine=engine)
+
+
+def _grid_network() -> Network:
+    """A small 3x3 grid of nodes with 12 bidirectional links (length 100 each).
+
+    Layout::
+
+        7 - 8 - 9
+        |   |   |
+        4 - 5 - 6
+        |   |   |
+        1 - 2 - 3
+
+    Links (id, from, to, length):
+      Horizontals: 1->2 (l=100), 2->3 (l=100), 4->5, 5->6, 7->8, 8->9
+      Verticals:   1->4, 2->5, 3->6, 4->7, 5->8, 6->9
+
+    All directed=False (so the GraphIndex adds both directions).
+    Coordinates are placed on a unit grid (0..2 in each dim).
+    """
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0, "zone_id": 1},
+            {"node_id": 2, "x_coord": 1.0, "y_coord": 0.0, "zone_id": 1},
+            {"node_id": 3, "x_coord": 2.0, "y_coord": 0.0, "zone_id": 2},
+            {"node_id": 4, "x_coord": 0.0, "y_coord": 1.0, "zone_id": 1},
+            {"node_id": 5, "x_coord": 1.0, "y_coord": 1.0, "zone_id": 2},
+            {"node_id": 6, "x_coord": 2.0, "y_coord": 1.0, "zone_id": 2},
+            {"node_id": 7, "x_coord": 0.0, "y_coord": 2.0, "zone_id": 3},
+            {"node_id": 8, "x_coord": 1.0, "y_coord": 2.0, "zone_id": 3},
+            {"node_id": 9, "x_coord": 2.0, "y_coord": 2.0, "zone_id": 3},
+        ],
+    )
+    horizontals = [
+        (1, 1, 2),
+        (2, 2, 3),
+        (3, 4, 5),
+        (4, 5, 6),
+        (5, 7, 8),
+        (6, 8, 9),
+    ]
+    verticals = [
+        (7, 1, 4),
+        (8, 2, 5),
+        (9, 3, 6),
+        (10, 4, 7),
+        (11, 5, 8),
+        (12, 6, 9),
+    ]
+    link_rows = []
+    for lid, frm, to in horizontals + verticals:
+        # Build a tiny WKT linestring from the node coords for spatial-buffer tests.
+        x1 = (frm - 1) % 3
+        y1 = (frm - 1) // 3
+        x2 = (to - 1) % 3
+        y2 = (to - 1) // 3
+        link_rows.append(
+            {
+                "link_id": lid,
+                "from_node_id": frm,
+                "to_node_id": to,
+                "length": 100.0,
+                "directed": False,
+                "geometry": f"LINESTRING ({x1} {y1}, {x2} {y2})",
+            }
+        )
+    return _network({"link": _link(engine, link_rows), "node": nodes})
+
+
+# ---------------------------------------------------------------------------
+# Distance parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_distance_numeric_is_meters():
+    from gmnspy.scope.scope import _parse_distance
+
+    assert _parse_distance(800) == 800.0
+    assert _parse_distance(0.5) == 0.5
+
+
+def test_parse_distance_units():
+    from gmnspy.scope.scope import _parse_distance
+
+    assert _parse_distance("0.5mi") == pytest.approx(804.672)
+    assert _parse_distance("1km") == 1000.0
+    assert _parse_distance("100ft") == pytest.approx(30.48)
+
+
+def test_parse_distance_rejects_bad_input():
+    from gmnspy.scope import ScopeError
+    from gmnspy.scope.scope import _parse_distance
+
+    with pytest.raises(ScopeError, match="Unparseable"):
+        _parse_distance("not-a-distance")
+    with pytest.raises(ScopeError, match="Unknown distance unit"):
+        _parse_distance("5parsecs")
+
+
+# ---------------------------------------------------------------------------
+# Constructors
+# ---------------------------------------------------------------------------
+
+
+def test_from_nodes_no_path_between():
+    """Seeds with path_between=False -> just the seed nodes + incident links."""
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [1, 2], path_between=False)
+    assert scope.node_ids == frozenset({1, 2})
+    # Only link 1 (1->2) has both endpoints in {1, 2}.
+    assert scope.link_ids == frozenset({1})
+
+
+def test_from_nodes_path_between_includes_path_nodes():
+    """Seeds {1, 9} with path_between -> include nodes on the shortest path."""
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [1, 9], path_between=True)
+    # Path is 1->2->5->8->9 or 1->4->5->6->9 etc.; all length-4 paths.
+    assert {1, 9} <= scope.node_ids
+    # Must include at least one intermediate node.
+    assert len(scope.node_ids) > 2
+
+
+def test_from_nodes_drops_unknown_ids():
+    """Loose lists with unknown ids don't raise; the unknown ones just don't show up."""
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [1, 999, 1000], path_between=False)
+    assert scope.node_ids == frozenset({1})
+
+
+def test_from_node_network_buffer():
+    """Buffer of 100m from node 5 -> reaches its 4 immediate neighbours (2, 4, 6, 8)."""
+    from gmnspy.scope import from_node
+
+    net = _grid_network()
+    scope = from_node(net, 5, network_buffer="100m")
+    # Each grid edge is length 100, so 100m buffer reaches the 1-hop neighbours.
+    assert {2, 4, 5, 6, 8} <= scope.node_ids
+    # And NOT the corners (which are 200m away).
+    assert {1, 3, 7, 9}.isdisjoint(scope.node_ids)
+
+
+def test_from_node_rejects_unknown_seed():
+    from gmnspy.scope import ScopeError, from_node
+
+    net = _grid_network()
+    with pytest.raises(ScopeError, match="9999"):
+        from_node(net, 9999, network_buffer="50m")
+
+
+def test_from_link_spatial_buffer_returns_neighbours():
+    """Spatial buffer of 1.5 around link 1 (1->2 at y=0) should find the parallel link at y=1.
+
+    Link 1 geometry: (0,0)-(1,0). A 1.5-unit buffer reaches links at y=1
+    too (distance is 1.0).
+    """
+    from gmnspy.scope import from_link
+
+    net = _grid_network()
+    scope = from_link(net, 1, spatial_buffer_m=1.5)
+    assert 1 in scope.link_ids  # seed always included
+    # Links along y=1 (ids 3, 4) should fall inside the buffer.
+    assert {3, 4} & scope.link_ids
+
+
+def test_from_link_network_buffer():
+    """Network buffer 100m from link 1 (1->2) reaches each endpoint's 1-hop neighbours."""
+    from gmnspy.scope import from_link
+
+    net = _grid_network()
+    scope = from_link(net, 1, network_buffer="100m")
+    # From {1, 2} expanding by 100m reaches {4, 5} via verticals + horizontals.
+    assert {1, 2} <= scope.node_ids
+    assert {4, 5} <= scope.node_ids
+
+
+def test_from_link_requires_exactly_one_buffer_kind():
+    from gmnspy.scope import ScopeError, from_link
+
+    net = _grid_network()
+    with pytest.raises(ScopeError, match="exactly one"):
+        from_link(net, 1)
+    with pytest.raises(ScopeError, match="exactly one"):
+        from_link(net, 1, spatial_buffer_m=10, network_buffer="50m")
+
+
+def test_from_point_snaps_and_buffers():
+    """Point near (0, 0) with a 1.5 buffer should find links incident to node 1."""
+    from gmnspy.scope import from_point
+
+    net = _grid_network()
+    scope = from_point(net, (0.0, 0.0), spatial_buffer_m=1.5)
+    # Link 1 (1->2) starts at (0,0) — must be in the buffer.
+    assert 1 in scope.link_ids
+    # Link 7 (1->4) starts at (0,0) — must also be there.
+    assert 7 in scope.link_ids
+
+
+def test_connected_component_returns_whole_component():
+    """connected_component on the grid returns all 9 nodes + all 12 links."""
+    from gmnspy.scope import connected_component
+
+    net = _grid_network()
+    scope = connected_component(net, 1)
+    assert scope.node_ids == frozenset(range(1, 10))
+    assert scope.link_ids == frozenset(range(1, 13))
+
+
+def test_connected_component_rejects_unknown_seed():
+    from gmnspy.scope import ScopeError, connected_component
+
+    net = _grid_network()
+    with pytest.raises(ScopeError, match="9999"):
+        connected_component(net, 9999)
+
+
+def test_from_zone_filters_by_node_zone_id():
+    """Zone 1 contains nodes 1, 2, 4 -> incident-only links {1, 7} (1->2, 1->4)."""
+    from gmnspy.scope import from_zone
+
+    net = _grid_network()
+    scope = from_zone(net, [1])
+    assert scope.node_ids == frozenset({1, 2, 4})
+    # Only links with BOTH endpoints in {1,2,4}: 1->2 and 1->4.
+    assert scope.link_ids == frozenset({1, 7})
+
+
+def test_from_zone_requires_zone_id_column():
+    from gmnspy.scope import ScopeError, from_zone
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])  # no zone_id
+    links = _link(engine, [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "length": 0.0}])
+    net = _network({"link": links, "node": nodes})
+    with pytest.raises(ScopeError, match="zone_id"):
+        from_zone(net, [1])
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+def test_union():
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    s1 = from_nodes(net, [1, 2], path_between=False)
+    s2 = from_nodes(net, [2, 3], path_between=False)
+    u = s1.union(s2)
+    assert u.node_ids == frozenset({1, 2, 3})
+
+
+def test_intersect():
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    s1 = from_nodes(net, [1, 2, 4], path_between=False)
+    s2 = from_nodes(net, [2, 5], path_between=False)
+    inter = s1.intersect(s2)
+    assert inter.node_ids == frozenset({2})
+
+
+def test_subtract():
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    s1 = from_nodes(net, [1, 2, 4], path_between=False)
+    s2 = from_nodes(net, [4], path_between=False)
+    diff = s1.subtract(s2)
+    assert diff.node_ids == frozenset({1, 2})
+
+
+def test_compose_rejects_cross_network():
+    from gmnspy.scope import ScopeError, from_nodes
+
+    net1 = _grid_network()
+    net2 = _grid_network()
+    s1 = from_nodes(net1, [1], path_between=False)
+    s2 = from_nodes(net2, [1], path_between=False)
+    with pytest.raises(ScopeError, match="different networks"):
+        s1.union(s2)
+
+
+def test_buffer_network_extends_scope():
+    """buffer_network(100) on {5} reaches 1-hop neighbours."""
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [5], path_between=False).buffer_network("100m")
+    assert {2, 4, 5, 6, 8} <= scope.node_ids
+
+
+def test_buffer_spatial_extends_scope():
+    """buffer_spatial(1.5) on link 1 picks up nearby parallel links."""
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [1, 2], path_between=False).buffer_spatial(1.5)
+    # Original link 1 + spatially close ones along y=0/y=1.
+    assert 1 in scope.link_ids
+
+
+# ---------------------------------------------------------------------------
+# Apply (FK pushdown)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_filters_link_and_node_tables():
+    from gmnspy.scope import from_nodes
+
+    net = _grid_network()
+    scope = from_nodes(net, [1, 2], path_between=False)
+    sub = scope.apply()
+    # Node table filtered to scope's node ids.
+    node_ids = set(sub.nodes.to_pandas()["node_id"].tolist())
+    assert node_ids == {1, 2}
+    # Link table filtered to scope's link ids.
+    link_ids = set(sub.links.to_pandas()["link_id"].tolist())
+    assert link_ids == {1}
+
+
+def test_apply_filters_geometry_via_link_geometry_id():
+    """The geometry table is filtered to only ids referenced by the surviving links."""
+    from gmnspy.scope import from_nodes
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": i, "x_coord": 0.0, "y_coord": 0.0} for i in (1, 2, 3)])
+    links = _link(
+        engine,
+        [
+            {"link_id": 1, "from_node_id": 1, "to_node_id": 2, "length": 1.0, "geometry_id": 100},
+            {"link_id": 2, "from_node_id": 2, "to_node_id": 3, "length": 1.0, "geometry_id": 200},
+        ],
+    )
+    geometry = Table(
+        name="geometry",
+        expr=engine.from_records(
+            [
+                {"geometry_id": 100, "geometry": "LINESTRING (0 0, 1 0)"},
+                {"geometry_id": 200, "geometry": "LINESTRING (1 0, 2 0)"},
+                {"geometry_id": 300, "geometry": "LINESTRING (5 5, 6 6)"},  # orphan
+            ]
+        ),
+        engine=engine,
+    )
+    net = _network({"link": links, "node": nodes, "geometry": geometry})
+    scope = from_nodes(net, [1, 2], path_between=False)
+    sub = scope.apply()
+    kept_geom_ids = set(sub.geometry.to_pandas()["geometry_id"].tolist())
+    # Only link 1 (geometry_id=100) survives the scope.
+    assert kept_geom_ids == {100}
+
+
+def test_apply_filters_link_tod():
+    """link_tod rows survive only when their link_id is in the kept link set."""
+    from gmnspy.scope import from_nodes
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": i, "x_coord": 0.0, "y_coord": 0.0} for i in (1, 2, 3)])
+    links = _link(
+        engine,
+        [
+            {"link_id": 1, "from_node_id": 1, "to_node_id": 2, "length": 1.0},
+            {"link_id": 2, "from_node_id": 2, "to_node_id": 3, "length": 1.0},
+        ],
+    )
+    link_tod = Table(
+        name="link_tod",
+        expr=engine.from_records(
+            [
+                {"link_tod_id": 100, "link_id": 1, "timeday_id": "am"},
+                {"link_tod_id": 200, "link_id": 2, "timeday_id": "am"},
+            ]
+        ),
+        engine=engine,
+    )
+    net = _network({"link": links, "node": nodes, "link_tod": link_tod})
+    scope = from_nodes(net, [1, 2], path_between=False)  # picks link 1
+    sub = scope.apply()
+    link_tod_ids = set(sub.tables["link_tod"].to_pandas()["link_tod_id"].tolist())
+    assert link_tod_ids == {100}
+
+
+# ---------------------------------------------------------------------------
+# Index caching (perf-relevant)
+# ---------------------------------------------------------------------------
+
+
+def test_graph_index_is_cached_on_network():
+    """First scope call builds + caches; second call reuses (no rebuild)."""
+    from gmnspy.scope import connected_component
+    from gmnspy.scope.scope import _GRAPH_INDEX_KEY
+
+    net = _grid_network()
+    assert _GRAPH_INDEX_KEY not in net.metadata
+    connected_component(net, 1)
+    cached = net.metadata[_GRAPH_INDEX_KEY]
+    connected_component(net, 2)
+    assert net.metadata[_GRAPH_INDEX_KEY] is cached
+
+
+def test_scope_shares_index_cache_with_semantics():
+    """gmnspy.semantics.connectivity and gmnspy.scope share the same cache key."""
+    from gmnspy.scope.scope import _GRAPH_INDEX_KEY as scope_key
+    from gmnspy.semantics.connectivity import _GRAPH_INDEX_KEY as semantics_key
+
+    assert scope_key == semantics_key
+
+
+def test_leavenworth_smoke():
+    """Smoke test on Leavenworth — scope ops complete without raising."""
+    from gmnspy.scope import connected_component, from_nodes
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=_engine())
+    # connected_component on any node returns all of them (single component).
+    seed_node = int(net.nodes.to_pandas()["node_id"].iloc[0])
+    comp = connected_component(net, seed_node)
+    assert len(comp.node_ids) == net.nodes.count()
+    # from_nodes returns a non-empty scope.
+    scope = from_nodes(net, [seed_node], path_between=False)
+    assert seed_node in scope.node_ids


### PR DESCRIPTION
## Summary

Implements **task 3.10** — network-aware scope on top of the `GraphIndex` + `SpatialIndex` from batch 2 and the connected-component primitive from 3.8. Closes #78.

### Architecture

- **`NetworkScope`** (frozen dataclass) carries `(node_ids, link_ids, network, provenance)`.
- **Composition**: `.union()`, `.intersect()`, `.subtract()`, `.buffer_network(distance)`, `.buffer_spatial(distance_m)`. Each returns a new `NetworkScope`. Cross-network composition raises.
- **Constructors** (all module-level functions, GMNS-aware):
  - `from_nodes(net, ids, *, path_between=True)` — BFS / shortest-path induced subgraph; `path_between=False` is the cheaper "just these seeds + incident links" mode.
  - `from_node(net, id, *, network_buffer="0.5mi")` — Dijkstra-bounded.
  - `from_link(net, id, *, spatial_buffer_m | network_buffer)` — exactly one buffer kind required.
  - `from_point(net, (x, y), *, spatial_buffer_m=100)` — snaps to nearest links via SpatialIndex.
  - `connected_component(net, seed)` — whole weakly-connected component.
  - `from_zone(net, zone_ids)` — filter by `node.zone_id`.
- **`NetworkScope.apply()`** returns a new `Network` whose tables are filtered by FK pushdown — `link`/`node`/`geometry` direct; `link_tod` / `lane` / `segment` / `movement` / `signal_*` via the static `_FK_PUSHDOWN` map. Unknown tables pass through (documented).
- **Distance parser** (`_parse_distance`) accepts `"0.5mi"`, `"800m"`, `"1km"`, `"100ft"` + spelled-out variants. Bare numbers are meters (matches `link.length`).
- **Auto-build heuristic**: emits an info-level log when building a graph index on a network with > 50k nodes. Override with `GMNSPY_AUTO_INDEX_THRESHOLD` env var.
- **Shared cache**: uses the same `_cached_graph_index` key as `gmnspy.semantics.connectivity` so the two modules don't double-build.

### Design call

Single `scope.py` file (~600 LOC) per Lens C — all constructors + composition share the FK-pushdown pattern and read more cleanly side-by-side than spread across N files. The `_FK_PUSHDOWN` dict at the top is declarative and easy to extend; the supporting pyarrow helpers are local.

## Test plan

- [x] 28 new tests in `packages/gmnspy/tests/test_scope.py` — exact node/link set assertions on a 3×3 grid network for every constructor + composition op + `apply` + geometry/link_tod FK pushdown + cache reuse + Leavenworth smoke.
- [x] 4 new doctests on `NetworkScope` + key constructors.
- [x] Full suite: **693 → 721 passing**.
- [x] `ruff check` / `ruff format --check` / `lint-imports` / `lint_no_sql` all clean.

## Out of scope (deferred)

- **Cache-hit perf test** (≥10× faster after first build) — listed in the original plan but skipped here because micro-benchmarking timing on a 3×3 grid is noisy. Will land alongside the regional synthetic fixture in Phase 4 bench work.
- **Polygon scope** — listed as a stretch in the original plan; the generic `datagrove.dataset.view.from_polygon` already covers spatial-polygon needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)