### PR TITLE
feat(clean): network-editing ops with atomic rollback (#81)

### DIFF
--- a/packages/gmnspy/gmnspy/clean/__init__.py
+++ b/packages/gmnspy/gmnspy/clean/__init__.py
@@ -1,5 +1,39 @@
-"""OPTIONAL EXTRA - network editing (simplify, merge, snap).
+"""OPTIONAL EXTRA — network editing with atomic rollback + audit log.
 
-Atomic rollback + audit log via ``datagrove.editing``. Install via
-``pip install gmnspy[clean]``.
+Install via ``pip install gmnspy[clean]`` to pick up shapely + igraph.
+
+Each op composes with :class:`datagrove.editing.Session`:
+
+    >>> import pytest
+    >>> _ = pytest.importorskip("shapely")
+    >>> # (See packages/gmnspy/tests/test_clean.py for runnable examples.)
+
+Ops in this release:
+
+* :func:`simplify_geometry` — drop redundant vertices or Douglas-Peucker
+  simplify.
+* :func:`merge_close_nodes` — collapse near-duplicate node pairs;
+  rewrite incident links.
+* :func:`remove_orphans` — drop nodes with no incident links.
+* :func:`recompute_lengths` — set ``link.length`` from geometry
+  (planar by default; ``geodesic=True`` for WGS84 haversine).
+
+Deferred for follow-up (filed as issues): ``split_link_at_node``,
+``connect_disconnected_components``, ``snap_to_reference``.
 """
+
+from .clean import (
+    merge_close_nodes,
+    recompute_lengths,
+    remove_orphans,
+    simplify_geometry,
+)
+from .errors import CleanError
+
+__all__ = [
+    "CleanError",
+    "merge_close_nodes",
+    "recompute_lengths",
+    "remove_orphans",
+    "simplify_geometry",
+]

--- a/packages/gmnspy/gmnspy/clean/clean.py
+++ b/packages/gmnspy/gmnspy/clean/clean.py
@@ -1,0 +1,420 @@
+"""Network-editing ops (gmnspy.clean) — optional ``[clean]`` extra.
+
+Each op:
+
+* Computes the new state of the affected table(s) in pyarrow.
+* Builds one :class:`datagrove.editing.Edit` with ``op="replace_table"``
+  per affected table and pushes it through the open
+  :class:`datagrove.editing.Session`.
+* Returns the :class:`~datagrove.editing.EditResult` so the caller can
+  inspect the diff + roll back if needed.
+
+Rollback fidelity is exact: ``replace_table`` captures the previous
+expression in the rollback record, and :meth:`Session.rollback` restores
+it byte-for-byte (via ``Engine.from_arrow`` round-tripping).
+
+Why ``replace_table`` and not surgical per-row updates: the cleanups
+here change many rows at once (every link's geometry, every node merge
+relabels all incident links, …) and the bulk-replace path is simpler
+to reason about + cleaner to roll back than threading row-level edits.
+For tiny network sizes this is a non-issue; for regional-scale a
+follow-up could specialise the hot paths.
+
+Ops shipping in this PR:
+
+* :func:`simplify_geometry` — drop redundant collinear vertices or
+  Douglas-Peucker simplify each link's geometry.
+* :func:`merge_close_nodes` — collapse node clusters within a
+  threshold distance to a single survivor; rewrite incident links.
+* :func:`remove_orphans` — drop nodes with no incident links.
+* :func:`recompute_lengths` — set ``link.length`` to the geometry's
+  geodesic length (degrees-aware approximation via shapely).
+
+Deferred for follow-up (not in this PR):
+
+* ``split_link_at_node`` — needs careful handling of mid-link node
+  insertion + new link_id minting.
+* ``connect_disconnected_components`` — needs synthetic-link policy
+  + max-distance bound.
+* ``snap_to_reference`` — needs CRS-aware nearest-neighbour matching.
+
+Each op signature takes the :class:`Network` + the open
+:class:`Session` (the session is the rollback boundary; passing it
+explicitly keeps the integration with ``datagrove.editing`` visible
+in every call site).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+# Guard the optional [clean] extra up front so an import-time error is
+# obvious and points the user at the install command. The actual shapely
+# usage is inside each op.
+try:
+    import shapely  # noqa: F401
+except ImportError as e:  # pragma: no cover - defensive
+    raise ImportError("gmnspy.clean requires the [clean] extra: pip install 'gmnspy[clean]'") from e
+
+import pyarrow as pa
+from datagrove.editing import Edit, EditResult, Session
+
+from .errors import CleanError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gmnspy.network import Network
+
+__all__ = [
+    "merge_close_nodes",
+    "recompute_lengths",
+    "remove_orphans",
+    "simplify_geometry",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — pyarrow access, edit submission
+# ---------------------------------------------------------------------------
+
+
+def _to_arrow(table) -> pa.Table:
+    """Materialise a :class:`~datagrove.dataset.Table` to pyarrow."""
+    return pa.Table.from_pandas(table.to_pandas(), preserve_index=False)
+
+
+def _submit_replace(session: Session, table_name: str, new_rows: list[dict]) -> EditResult:
+    """Submit a ``replace_table`` Edit for ``table_name`` carrying ``new_rows``.
+
+    Uses the package's engine to materialise the new expression from
+    plain row dicts — same path as :meth:`Engine.from_records` so we
+    stay backend-agnostic.
+    """
+    engine = session.package.engine
+    new_expr = engine.from_records(new_rows)
+    edit = Edit(op="replace_table", table=table_name, payload={"expr": new_expr})
+    return session.add_edit(edit)
+
+
+# ---------------------------------------------------------------------------
+# Op 1 — simplify_geometry
+# ---------------------------------------------------------------------------
+
+
+def simplify_geometry(
+    net: Network,
+    session: Session,
+    *,
+    mode: str = "redundant_only",
+    tolerance: float = 0.0,
+) -> EditResult:
+    """Drop redundant interior vertices on every link geometry.
+
+    Args:
+        net: The source :class:`Network`. Must have a ``link.geometry``
+            column (inline WKT). If geometry is carried via
+            ``geometry_id``, assemble it first with
+            :func:`gmnspy.semantics.assemble_link_geometry` then push the
+            result onto a column named ``geometry`` before calling.
+        session: An open :class:`datagrove.editing.Session` bound to
+            ``net``. The returned :class:`EditResult` is appended to
+            the session's log so :meth:`Session.rollback` can undo it.
+        mode: ``"redundant_only"`` (default) drops vertices that are
+            collinear with their neighbours within ``tolerance``. No
+            spatial accuracy is lost when ``tolerance == 0.0``.
+            ``"douglas_peucker"`` runs shapely's
+            :meth:`shapely.geometry.LineString.simplify` with the given
+            ``tolerance`` (CRS units).
+        tolerance: Threshold in CRS units. For ``redundant_only`` this
+            is the maximum perpendicular distance a vertex can sit
+            from the chord through its neighbours before it is
+            considered non-redundant. For ``douglas_peucker`` it is
+            the shapely tolerance.
+
+    Returns:
+        An :class:`EditResult` describing the bulk ``replace_table``
+        edit on ``link``.
+
+    Raises:
+        CleanError: If ``net.links`` lacks an inline ``geometry`` column
+            or ``mode`` is unrecognised.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("shapely")
+        >>> from gmnspy import Network
+        >>> from datagrove.editing import Session
+        >>> # (See packages/gmnspy/tests/test_clean.py for runnable examples.)
+        >>> simplify_geometry  # doctest: +ELLIPSIS
+        <function simplify_geometry at ...>
+    """
+    from shapely import from_wkt
+
+    if "geometry" not in net.links.columns():
+        raise CleanError(
+            "simplify_geometry requires an inline 'geometry' column on net.links; "
+            "use gmnspy.semantics.assemble_link_geometry first if your network "
+            "carries geometry via geometry_id."
+        )
+    if mode not in {"redundant_only", "douglas_peucker"}:
+        raise CleanError(f"simplify_geometry mode must be 'redundant_only' or 'douglas_peucker'; got {mode!r}.")
+
+    arrow = _to_arrow(net.links)
+    new_rows: list[dict] = arrow.to_pylist()
+    for row in new_rows:
+        wkt = row.get("geometry")
+        if wkt is None or not str(wkt).strip():
+            continue
+        try:
+            geom = from_wkt(str(wkt))
+        except Exception:  # pragma: no cover - shapely raises broadly
+            continue
+        if geom is None or geom.is_empty or geom.geom_type != "LineString":
+            continue
+        if mode == "douglas_peucker":
+            simplified = geom.simplify(tolerance, preserve_topology=False)
+        else:
+            simplified = _drop_collinear(geom, tolerance=tolerance)
+        if simplified is geom or simplified.is_empty:
+            continue
+        row["geometry"] = simplified.wkt
+    return _submit_replace(session, "link", new_rows)
+
+
+def _drop_collinear(linestring, *, tolerance: float):
+    """Return a :class:`shapely.LineString` with redundant interior vertices removed.
+
+    A vertex is redundant when its perpendicular distance from the
+    chord through its previous + next neighbour is <= ``tolerance``.
+    With ``tolerance == 0.0`` only strictly-collinear vertices drop —
+    no spatial accuracy is lost.
+    """
+    from shapely.geometry import LineString
+
+    coords = [tuple(c[:2]) for c in linestring.coords]
+    if len(coords) <= 2:
+        return linestring
+    keep = [coords[0]]
+    for i in range(1, len(coords) - 1):
+        prev = keep[-1]
+        nxt = coords[i + 1]
+        if _perp_distance(prev, coords[i], nxt) > tolerance:
+            keep.append(coords[i])
+    keep.append(coords[-1])
+    if len(keep) == len(coords):
+        return linestring  # nothing dropped
+    return LineString(keep)
+
+
+def _perp_distance(a: tuple[float, float], b: tuple[float, float], c: tuple[float, float]) -> float:
+    """Perpendicular distance from point ``b`` to the line through ``a`` and ``c``.
+
+    Returns 0.0 when ``a`` and ``c`` coincide (degenerate chord).
+    """
+    ax, ay = a
+    bx, by = b
+    cx, cy = c
+    chord_dx = cx - ax
+    chord_dy = cy - ay
+    chord_len = math.hypot(chord_dx, chord_dy)
+    if chord_len == 0.0:
+        return 0.0
+    # |(b-a) x (c-a)| / |c-a|
+    cross = (bx - ax) * chord_dy - (by - ay) * chord_dx
+    return abs(cross) / chord_len
+
+
+# ---------------------------------------------------------------------------
+# Op 2 — merge_close_nodes
+# ---------------------------------------------------------------------------
+
+
+def merge_close_nodes(
+    net: Network,
+    session: Session,
+    *,
+    threshold_m: float = 5.0,
+) -> list[EditResult]:
+    """Merge pairs of nodes within ``threshold_m`` of each other.
+
+    Survivor selection: lowest ``node_id`` per cluster. All incident
+    links have their ``from_node_id`` / ``to_node_id`` rewritten to
+    the survivor. Merged nodes are dropped from the node table.
+
+    Args:
+        net: Source :class:`Network`.
+        session: Open :class:`Session`.
+        threshold_m: Distance threshold in node CRS units (meters for
+            projected coords; degrees for WGS84 — tune accordingly).
+
+    Returns:
+        A list of :class:`EditResult` — one for the ``node`` replace
+        and one for the ``link`` replace.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("shapely")
+        >>> merge_close_nodes  # doctest: +ELLIPSIS
+        <function merge_close_nodes at ...>
+    """
+    nodes_arrow = _to_arrow(net.nodes)
+    links_arrow = _to_arrow(net.links)
+
+    rows = list(
+        zip(
+            nodes_arrow.column("node_id").to_pylist(),
+            nodes_arrow.column("x_coord").to_pylist(),
+            nodes_arrow.column("y_coord").to_pylist(),
+            strict=True,
+        )
+    )
+    clean = [(nid, float(x), float(y)) for nid, x, y in rows if nid is not None and x is not None and y is not None]
+    threshold_sq = threshold_m * threshold_m
+
+    # Build an id -> survivor mapping via simple greedy clustering.
+    # For N < ~10k this is fine; for regional-scale we'd swap in an
+    # STRtree-based clusterer (filed as future work).
+    survivor: dict[Any, Any] = {nid: nid for nid, _, _ in clean}
+    for i in range(len(clean)):
+        id_i, xi, yi = clean[i]
+        for j in range(i + 1, len(clean)):
+            id_j, xj, yj = clean[j]
+            dx, dy = xi - xj, yi - yj
+            if dx * dx + dy * dy > threshold_sq:
+                continue
+            # Merge into the lower of the two survivors.
+            keep = min(survivor[id_i], survivor[id_j], key=_sort_key)
+            survivor[id_i] = keep
+            survivor[id_j] = keep
+    # Resolve chains so survivor[x] is always a root.
+    for k in list(survivor):
+        seen = set()
+        cur = k
+        while survivor[cur] != cur and cur not in seen:
+            seen.add(cur)
+            cur = survivor[cur]
+        survivor[k] = cur
+
+    # Filter the node table to keep only survivors.
+    new_node_rows = [row for row in nodes_arrow.to_pylist() if row.get("node_id") in survivor.values()]
+
+    # Rewrite link from/to ids to survivors.
+    new_link_rows = []
+    for row in links_arrow.to_pylist():
+        new_row = dict(row)
+        if (from_id := row.get("from_node_id")) in survivor:
+            new_row["from_node_id"] = survivor[from_id]
+        if (to_id := row.get("to_node_id")) in survivor:
+            new_row["to_node_id"] = survivor[to_id]
+        new_link_rows.append(new_row)
+
+    return [
+        _submit_replace(session, "node", new_node_rows),
+        _submit_replace(session, "link", new_link_rows),
+    ]
+
+
+def _sort_key(value: Any) -> tuple[int, Any]:
+    """Sort key that handles mixed-type ids (ints first by value, then strings)."""
+    if isinstance(value, (int, float)):
+        return (0, value)
+    return (1, str(value))
+
+
+# ---------------------------------------------------------------------------
+# Op 3 — remove_orphans
+# ---------------------------------------------------------------------------
+
+
+def remove_orphans(net: Network, session: Session) -> EditResult:
+    """Drop nodes with no incident links.
+
+    Args:
+        net: Source :class:`Network`.
+        session: Open :class:`Session`.
+
+    Returns:
+        An :class:`EditResult` describing the ``node`` replace.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("shapely")
+        >>> remove_orphans  # doctest: +ELLIPSIS
+        <function remove_orphans at ...>
+    """
+    links_arrow = _to_arrow(net.links)
+    incident: set[Any] = set()
+    for v in links_arrow.column("from_node_id").to_pylist():
+        if v is not None:
+            incident.add(v)
+    for v in links_arrow.column("to_node_id").to_pylist():
+        if v is not None:
+            incident.add(v)
+
+    nodes_arrow = _to_arrow(net.nodes)
+    new_node_rows = [row for row in nodes_arrow.to_pylist() if row.get("node_id") in incident]
+    return _submit_replace(session, "node", new_node_rows)
+
+
+# ---------------------------------------------------------------------------
+# Op 4 — recompute_lengths
+# ---------------------------------------------------------------------------
+
+
+def recompute_lengths(net: Network, session: Session, *, geodesic: bool = False) -> EditResult:
+    """Recompute ``link.length`` from the inline geometry.
+
+    Args:
+        net: Source :class:`Network`. Must have a ``link.geometry``
+            column (inline WKT).
+        session: Open :class:`Session`.
+        geodesic: When ``True``, treat geometry coords as
+            (lon, lat) in WGS84 and compute haversine length in meters.
+            When ``False`` (default), report shapely's planar length
+            in CRS units (right for projected networks).
+
+    Returns:
+        An :class:`EditResult` describing the ``link`` replace.
+
+    Examples:
+        >>> import pytest
+        >>> _ = pytest.importorskip("shapely")
+        >>> recompute_lengths  # doctest: +ELLIPSIS
+        <function recompute_lengths at ...>
+    """
+    from shapely import from_wkt
+
+    if "geometry" not in net.links.columns():
+        raise CleanError("recompute_lengths requires an inline 'geometry' column on net.links.")
+
+    arrow = _to_arrow(net.links)
+    new_rows = arrow.to_pylist()
+    for row in new_rows:
+        wkt = row.get("geometry")
+        if wkt is None or not str(wkt).strip():
+            continue
+        try:
+            geom = from_wkt(str(wkt))
+        except Exception:  # pragma: no cover
+            continue
+        if geom is None or geom.is_empty or geom.geom_type != "LineString":
+            continue
+        row["length"] = _geodesic_length_m(geom) if geodesic else float(geom.length)
+    return _submit_replace(session, "link", new_rows)
+
+
+def _geodesic_length_m(linestring) -> float:
+    """Haversine length in meters for a (lon, lat) WGS84 LineString."""
+    from itertools import pairwise
+
+    earth_r = 6_371_000.0
+    coords = list(linestring.coords)
+    total = 0.0
+    for (lon1, lat1, *_), (lon2, lat2, *_) in pairwise(coords):
+        phi1 = math.radians(lat1)
+        phi2 = math.radians(lat2)
+        dphi = math.radians(lat2 - lat1)
+        dlam = math.radians(lon2 - lon1)
+        a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+        total += 2 * earth_r * math.asin(math.sqrt(a))
+    return total

--- a/packages/gmnspy/gmnspy/clean/errors.py
+++ b/packages/gmnspy/gmnspy/clean/errors.py
@@ -1,0 +1,16 @@
+"""Typed exceptions for :mod:`gmnspy.clean`."""
+
+from __future__ import annotations
+
+from datagrove.editing import EditingError
+
+__all__ = ["CleanError"]
+
+
+class CleanError(EditingError):
+    """A :mod:`gmnspy.clean` op cannot complete on the given inputs.
+
+    Subclass of :class:`datagrove.editing.EditingError` so generic
+    editing-error handlers still catch it. Raised for missing required
+    tables, malformed geometry, or invalid op parameters.
+    """

--- a/packages/gmnspy/tests/test_clean.py
+++ b/packages/gmnspy/tests/test_clean.py
@@ -1,0 +1,339 @@
+"""Tests for :mod:`gmnspy.clean` (task 3.12 / issue #81).
+
+Covers each op + a roundtrip-rollback assertion (apply, snapshot,
+rollback, verify state matches snapshot). Skipped wholesale if the
+``[clean]`` extra (shapely + igraph) is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from datagrove.dataset import Table
+from datagrove.editing import Session
+from datagrove.engines.pandas_engine import PandasEngine
+from datagrove.spec import DataPackage, Resource
+from gmnspy import Network
+
+pytest.importorskip("shapely")
+pytest.importorskip("igraph")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _engine() -> PandasEngine:
+    return PandasEngine()
+
+
+def _network(tables_dict: dict[str, Table]) -> Network:
+    engine = next(iter(tables_dict.values())).engine
+    spec = DataPackage(name="synthesized", resources=[Resource(name=n) for n in tables_dict])
+    return Network(spec=spec, tables=dict(tables_dict), engine=engine, spec_version="0.97")
+
+
+def _link(engine, rows: list[dict]) -> Table:
+    return Table(name="link", expr=engine.from_records(rows), engine=engine)
+
+
+def _node(engine, rows: list[dict]) -> Table:
+    return Table(name="node", expr=engine.from_records(rows), engine=engine)
+
+
+def _snapshot(net: Network) -> dict[str, list[dict]]:
+    """Return per-table row dicts for equality-comparison after rollback."""
+    return {name: net.tables[name].to_pandas().to_dict(orient="records") for name in net.tables}
+
+
+# ---------------------------------------------------------------------------
+# simplify_geometry
+# ---------------------------------------------------------------------------
+
+
+def test_simplify_geometry_drops_collinear_vertex():
+    """A 4-vertex straight line collapses to a 2-vertex line under redundant_only."""
+    from gmnspy.clean import simplify_geometry
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link(
+        engine,
+        [
+            {
+                "link_id": 1,
+                "from_node_id": 1,
+                "to_node_id": 1,
+                "geometry": "LINESTRING (0 0, 1 0, 2 0, 3 0)",
+            }
+        ],
+    )
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:
+        result = simplify_geometry(net, s)
+    new_wkt = net.links.to_pandas()["geometry"].iloc[0]
+    # Collapses to just the endpoints.
+    assert new_wkt == "LINESTRING (0 0, 3 0)"
+    assert result.diff.rows_changed >= 0  # bulk replace records a coarse diff
+
+
+def test_simplify_geometry_douglas_peucker_with_tolerance():
+    """A slight bend within tolerance gets smoothed under douglas_peucker."""
+    from gmnspy.clean import simplify_geometry
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    # The middle vertex is 0.1 units off the chord; tolerance 0.5 drops it.
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "geometry": "LINESTRING (0 0, 5 0.1, 10 0)"}],
+    )
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:
+        simplify_geometry(net, s, mode="douglas_peucker", tolerance=0.5)
+    new_wkt = net.links.to_pandas()["geometry"].iloc[0]
+    assert "0 0" in new_wkt and "10 0" in new_wkt
+    # Middle vertex 5 should be dropped.
+    assert "5" not in new_wkt.split(",")[1]
+
+
+def test_simplify_geometry_roundtrip_rollback():
+    """simplify_geometry -> rollback restores the original geometry exactly."""
+    from gmnspy.clean import simplify_geometry
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "geometry": "LINESTRING (0 0, 1 0, 2 0, 3 0)"}],
+    )
+    net = _network({"link": links, "node": nodes})
+    before = _snapshot(net)
+
+    s = Session(net)
+    with s:
+        simplify_geometry(net, s)
+        # Verify state CHANGED inside the with block.
+        assert net.links.to_pandas()["geometry"].iloc[0] != before["link"][0]["geometry"]
+        s.rollback()
+    after = _snapshot(net)
+    assert after == before
+
+
+def test_simplify_geometry_requires_geometry_column():
+    from gmnspy.clean import CleanError, simplify_geometry
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link(engine, [{"link_id": 1, "from_node_id": 1, "to_node_id": 1}])  # no geometry
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:  # noqa: SIM117
+        with pytest.raises(CleanError, match="geometry"):
+            simplify_geometry(net, s)
+
+
+# ---------------------------------------------------------------------------
+# merge_close_nodes
+# ---------------------------------------------------------------------------
+
+
+def test_merge_close_nodes_collapses_pair_and_rewrites_links():
+    from gmnspy.clean import merge_close_nodes
+
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 0.001, "y_coord": 0.0},  # within 5m of node 1
+            {"node_id": 3, "x_coord": 100.0, "y_coord": 100.0},  # far away
+        ],
+    )
+    links = _link(
+        engine,
+        [
+            {"link_id": 10, "from_node_id": 1, "to_node_id": 2},  # incident to merged pair
+            {"link_id": 20, "from_node_id": 2, "to_node_id": 3},  # one end merged
+        ],
+    )
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:
+        merge_close_nodes(net, s, threshold_m=1.0)
+
+    surviving_nodes = set(net.nodes.to_pandas()["node_id"].tolist())
+    # Node 2 merged into node 1 (lowest id wins).
+    assert surviving_nodes == {1, 3}
+
+    links_df = net.links.to_pandas().sort_values("link_id").reset_index(drop=True)
+    # link 10's to_node_id rewritten to 1; link 20's from_node_id rewritten to 1.
+    assert links_df.loc[0, "to_node_id"] == 1
+    assert links_df.loc[1, "from_node_id"] == 1
+
+
+def test_merge_close_nodes_roundtrip_rollback():
+    from gmnspy.clean import merge_close_nodes
+
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 0.001, "y_coord": 0.0},
+        ],
+    )
+    links = _link(engine, [{"link_id": 10, "from_node_id": 1, "to_node_id": 2}])
+    net = _network({"link": links, "node": nodes})
+    before = _snapshot(net)
+
+    s = Session(net)
+    with s:
+        merge_close_nodes(net, s, threshold_m=1.0)
+        s.rollback()
+    after = _snapshot(net)
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# remove_orphans
+# ---------------------------------------------------------------------------
+
+
+def test_remove_orphans_drops_node_with_no_links():
+    from gmnspy.clean import remove_orphans
+
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 1.0, "y_coord": 0.0},
+            {"node_id": 99, "x_coord": 5.0, "y_coord": 5.0},  # orphan
+        ],
+    )
+    links = _link(engine, [{"link_id": 1, "from_node_id": 1, "to_node_id": 2}])
+    net = _network({"link": links, "node": nodes})
+
+    with Session(net) as s:
+        remove_orphans(net, s)
+    surviving = set(net.nodes.to_pandas()["node_id"].tolist())
+    assert surviving == {1, 2}
+
+
+def test_remove_orphans_roundtrip_rollback():
+    from gmnspy.clean import remove_orphans
+
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 1.0, "y_coord": 0.0},
+            {"node_id": 99, "x_coord": 5.0, "y_coord": 5.0},
+        ],
+    )
+    links = _link(engine, [{"link_id": 1, "from_node_id": 1, "to_node_id": 2}])
+    net = _network({"link": links, "node": nodes})
+    before = _snapshot(net)
+
+    s = Session(net)
+    with s:
+        remove_orphans(net, s)
+        s.rollback()
+    assert _snapshot(net) == before
+
+
+# ---------------------------------------------------------------------------
+# recompute_lengths
+# ---------------------------------------------------------------------------
+
+
+def test_recompute_lengths_planar():
+    """Planar mode: length is shapely's geometric length (CRS units)."""
+    from gmnspy.clean import recompute_lengths
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    # Length should be 5.0 (3-4-5 triangle).
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "geometry": "LINESTRING (0 0, 3 0, 3 4)", "length": 999.0}],
+    )
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:
+        recompute_lengths(net, s)
+    new_length = float(net.links.to_pandas()["length"].iloc[0])
+    assert new_length == pytest.approx(7.0)  # 3 + 4 = 7 planar
+
+
+def test_recompute_lengths_geodesic_returns_meters():
+    """Geodesic mode: WGS84 (lon, lat) -> haversine length in meters."""
+    from gmnspy.clean import recompute_lengths
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    # 1 degree of longitude at the equator ≈ 111_320m. Using
+    # LINESTRING (0 0, 1 0) — should be approximately that distance.
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "geometry": "LINESTRING (0 0, 1 0)", "length": 0.0}],
+    )
+    net = _network({"link": links, "node": nodes})
+    with Session(net) as s:
+        recompute_lengths(net, s, geodesic=True)
+    new_length = float(net.links.to_pandas()["length"].iloc[0])
+    assert new_length == pytest.approx(111_195, rel=0.01)
+
+
+def test_recompute_lengths_roundtrip_rollback():
+    from gmnspy.clean import recompute_lengths
+
+    engine = _engine()
+    nodes = _node(engine, [{"node_id": 1, "x_coord": 0.0, "y_coord": 0.0}])
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 1, "geometry": "LINESTRING (0 0, 3 0, 3 4)", "length": 999.0}],
+    )
+    net = _network({"link": links, "node": nodes})
+    before = _snapshot(net)
+
+    s = Session(net)
+    with s:
+        recompute_lengths(net, s)
+        s.rollback()
+    assert _snapshot(net) == before
+
+
+# ---------------------------------------------------------------------------
+# Multiple ops in a single Session
+# ---------------------------------------------------------------------------
+
+
+def test_sequential_ops_chain_inside_one_session():
+    """Two ops in one session both apply; rollback at end restores baseline."""
+    from gmnspy.clean import recompute_lengths, remove_orphans
+
+    engine = _engine()
+    nodes = _node(
+        engine,
+        [
+            {"node_id": 1, "x_coord": 0.0, "y_coord": 0.0},
+            {"node_id": 2, "x_coord": 1.0, "y_coord": 0.0},
+            {"node_id": 99, "x_coord": 5.0, "y_coord": 5.0},  # orphan
+        ],
+    )
+    links = _link(
+        engine,
+        [{"link_id": 1, "from_node_id": 1, "to_node_id": 2, "geometry": "LINESTRING (0 0, 1 0)", "length": 0.0}],
+    )
+    net = _network({"link": links, "node": nodes})
+    before = _snapshot(net)
+
+    s = Session(net)
+    with s:
+        remove_orphans(net, s)
+        recompute_lengths(net, s)
+        # Both applied:
+        assert set(net.nodes.to_pandas()["node_id"]) == {1, 2}
+        assert float(net.links.to_pandas()["length"].iloc[0]) == pytest.approx(1.0)
+        s.rollback()
+    assert _snapshot(net) == before


### PR DESCRIPTION
## Summary

Implements **task 3.12** — `gmnspy.clean` (optional `[clean]` extra) on top of the generic `datagrove.editing` framework from Phase 2. Closes #81.

### Four ops shipped

| Op | What it does |
|---|---|
| `simplify_geometry(net, session, *, mode, tolerance)` | Drop redundant collinear vertices (`mode="redundant_only"`, lossless at `tolerance=0`) or Douglas-Peucker simplify. |
| `merge_close_nodes(net, session, *, threshold_m=5)` | Collapse node pairs within threshold; survivor = lowest `node_id`; incident links rewritten. Returns `[node_result, link_result]`. |
| `remove_orphans(net, session)` | Drop nodes with no incident links. |
| `recompute_lengths(net, session, *, geodesic=False)` | Set `link.length` to shapely's planar length (default) or WGS84 haversine in meters (`geodesic=True`). |

### Design

- **Composition over inheritance.** Each op takes the `Network` + an open `datagrove.editing.Session` explicitly. The framework owns rollback; ops just submit `Edit(op="replace_table", ...)` and return `EditResult`.
- **Bulk replace_table** chosen over surgical per-row updates: cleanup ops touch many rows at once and the rollback record is correspondingly simpler. For regional-scale a follow-up could specialise.
- **Optional-import guard** at module load — `import gmnspy.clean` raises a clear "install `gmnspy[clean]`" message when shapely is missing.
- **Single file (`clean.py`)** per Lens C — the ops share a shape (read → compute → submit replace_table); side-by-side reading helps.

### Deferred for follow-up

- `split_link_at_node` — needs mid-link node insertion + new `link_id` minting policy.
- `connect_disconnected_components` — needs synthetic-link policy + max-distance bound.
- `snap_to_reference` — needs CRS-aware nearest-neighbour matching.

## Test plan

- [x] 12 new tests in `packages/gmnspy/tests/test_clean.py` — every op + a roundtrip-rollback assertion per op + a multi-op chained-in-one-Session test.
- [x] Full suite: **735 → 747 passing**.
- [x] `ruff check` / `ruff format --check` / `lint-imports` / `lint_no_sql` all clean.
- [x] Doctests (5 in the module + init) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)