### PR TITLE
feat(cli): typer foundation + approval gating + gmnspy extension (Wave 1)

### DIFF
--- a/packages/datagrove/datagrove/cli/__init__.py
+++ b/packages/datagrove/datagrove/cli/__init__.py
@@ -1,11 +1,39 @@
 """Generic CLI for working with any Frictionless data package.
 
-Commands: validate, convert, info, scope (bbox/polygon/geometry-buffer
-only — network-aware scope is domain-specific), describe.
+Phase 4 task 4.1a (this module) ships the foundation: the
+:func:`build_app` factory + an ``app`` singleton wired to the
+``datagrove`` console-script entry point + two commands (``validate``,
+``info``) that prove the pattern. Subsequent Phase 4 tasks layer on
+``convert`` / ``scope`` / ``describe``.
 
-Entry point: ``datagrove = datagrove.cli.app:app``.
+Every command honours ``--json`` (machine-readable single-document
+stdout for agents) and ``--yes/-y`` (auto-approve gated ops; same as
+``DATAGROVE_AUTO_APPROVE=1``). See :mod:`datagrove.cli.prompts` for
+the approval-gating semantics.
 
-Domain packages (e.g. ``gmnspy``) extend this typer app via the plugin
-pattern so users get one unified command surface while the generic
-commands remain reusable across data specifications.
+Domain packages extend this CLI by calling :func:`build_app` then
+attaching their own commands — that's how :mod:`gmnspy.cli` adds the
+GMNS-aware commands onto the same surface.
 """
+
+from .app import app, build_app
+from .prompts import (
+    AUTO_APPROVE_ENV_VAR,
+    is_auto_approve,
+    prompt_approval,
+    run_with_approval,
+)
+from .render import console, render_dict, render_issues, render_table
+
+__all__ = [
+    "AUTO_APPROVE_ENV_VAR",
+    "app",
+    "build_app",
+    "console",
+    "is_auto_approve",
+    "prompt_approval",
+    "render_dict",
+    "render_issues",
+    "render_table",
+    "run_with_approval",
+]

--- a/packages/datagrove/datagrove/cli/app.py
+++ b/packages/datagrove/datagrove/cli/app.py
@@ -1,0 +1,126 @@
+"""Generic datagrove CLI — typer app + ``build_app()`` factory.
+
+Two entry points compose on the same factory:
+
+* ``datagrove = datagrove.cli.app:app`` ships only the generic
+  commands (validate, info — extended in Phase 4 task 4.2 with convert,
+  scope, describe).
+* ``gmnspy = gmnspy.cli.app:app`` calls :func:`build_app` to get a
+  fresh Typer with the generic commands, then layers GMNS-aware ones
+  on top (``quality``, GMNS-aware ``info``, etc.).
+
+Reusing the factory keeps both CLIs identical for the validate/info
+contract — same flags, same ``--json`` shape, same approval handling.
+
+Every command accepts ``--json`` (so an agent gets a single
+machine-readable document on stdout) and ``--yes/-y`` (auto-approve
+gated ops, see :mod:`datagrove.cli.prompts`).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+
+from datagrove.dataset import Package
+from datagrove.operations import ApprovalRequired
+
+from .prompts import run_with_approval
+from .render import console, render_dict, render_issues
+
+__all__ = ["app", "build_app"]
+
+logger = logging.getLogger(__name__)
+
+
+def build_app() -> typer.Typer:
+    """Return a fresh :class:`typer.Typer` with the generic datagrove commands.
+
+    Used by both the ``datagrove`` and ``gmnspy`` entry points so the
+    two CLIs share the same validate/info contracts. Domain extensions
+    (gmnspy) call this then attach their own commands; the returned
+    app is otherwise independent (calling :func:`build_app` twice
+    yields two unrelated apps).
+    """
+    typer_app = typer.Typer(
+        no_args_is_help=True,
+        rich_markup_mode="rich",
+        context_settings={"help_option_names": ["-h", "--help"]},
+        help=(
+            "datagrove — generic Frictionless data-package CLI. Add --json to any command for machine-readable output."
+        ),
+    )
+
+    @typer_app.command(name="validate")
+    def validate(
+        source: Path = typer.Argument(..., help="Path / URL to a data package (datapackage.json or table directory)."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout instead of rich panels."),
+        yes: bool = typer.Option(
+            False, "--yes", "-y", help="Auto-approve any gated ops (alternative to DATAGROVE_AUTO_APPROVE=1)."
+        ),
+    ) -> None:
+        """Validate ``source`` against its declared Frictionless schema.
+
+        Runs structural + schema + foreign-key + sync-state validators
+        and renders the resulting :class:`~datagrove.reports.ValidationReport`.
+        Exit code is non-zero iff any ERROR-severity issue is recorded.
+        """
+        package = Package.from_source(source)
+        try:
+            report = run_with_approval(package.validate, yes=yes)
+        except ApprovalRequired:
+            console.print("[yellow]validation declined — exiting 1.[/yellow]")
+            raise typer.Exit(code=1) from None
+        render_issues(report.issues, json_out=json_out, header=f"validation report: {source}")
+        # Exit non-zero on hard errors so CI / scripts can branch.
+        if any(getattr(i, "severity", None) and i.severity.value == "error" for i in report.issues):
+            raise typer.Exit(code=1)
+
+    @typer_app.command(name="info")
+    def info(
+        source: Path = typer.Argument(..., help="Path / URL to a data package."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout instead of rich panels."),
+    ) -> None:
+        """Print metadata about ``source`` — table list, row counts, spec name."""
+        package = Package.from_source(source)
+        data = {
+            "name": package.spec.name,
+            "source": str(source),
+            "engine": type(package.engine).__name__,
+            "table_count": len(package.tables),
+            "tables": _table_summary(package),
+        }
+        render_dict(data, json_out=json_out, title=f"info: {source}")
+
+    return typer_app
+
+
+def _table_summary(package: Package) -> list[dict]:
+    """Return ``[{name, rows, columns}]`` for every table in ``package``.
+
+    Materialises one row count per table; if a table is lazy and large,
+    the engine pushes the count down to its backend so this remains
+    cheap on regional-scale parquet sources.
+    """
+    out: list[dict] = []
+    for name, table in package.tables.items():
+        try:
+            row_count = table.count()
+            col_list = table.columns()
+        except Exception as exc:  # pragma: no cover - per-table resilience
+            logger.warning("info: skipping table %r — %s", name, exc)
+            continue
+        out.append({"name": name, "rows": row_count, "columns": col_list})
+    return out
+
+
+# The default ``datagrove`` entry point app — module-level so the
+# console script resolves it as `datagrove.cli.app:app`. Build it
+# once; consumers wanting a fresh app call :func:`build_app` again.
+app = build_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke
+    app()

--- a/packages/datagrove/datagrove/cli/prompts.py
+++ b/packages/datagrove/datagrove/cli/prompts.py
@@ -1,0 +1,109 @@
+"""Approval prompts + ``ApprovalRequired`` catcher (task 4.7, architecture §6.5).
+
+The cost model in :mod:`datagrove.operations` raises
+:class:`~datagrove.operations.ApprovalRequired` when an op exceeds the
+approval threshold. CLI commands wrap their gated calls with
+:func:`run_with_approval` (or use the lower-level
+:func:`prompt_approval` directly) so the human is asked once, the
+yes/no answer is recorded, and the wrapped call is retried with
+``approve=True``.
+
+Auto-approve channels (no prompt, immediate yes):
+
+* CLI flag ``--yes`` / ``-y`` — passed by the caller into ``yes=True``.
+* Env var ``DATAGROVE_AUTO_APPROVE=1`` — global escape hatch for
+  automation. Falsy ("0", empty, unset) means "prompt".
+
+Both channels are checked here so every CLI command honours them
+identically; commands only have to pass through their ``--yes`` flag.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from datagrove.operations import ApprovalRequired
+
+from .render import console
+
+__all__ = ["AUTO_APPROVE_ENV_VAR", "is_auto_approve", "prompt_approval", "run_with_approval"]
+
+logger = logging.getLogger(__name__)
+
+AUTO_APPROVE_ENV_VAR = "DATAGROVE_AUTO_APPROVE"
+
+T = TypeVar("T")
+
+
+def is_auto_approve() -> bool:
+    """Return ``True`` when ``DATAGROVE_AUTO_APPROVE`` env var is set truthy.
+
+    Truthy values: ``"1"``, ``"true"``, ``"yes"``, ``"y"`` (case-insensitive).
+    Anything else (including unset) is falsy.
+    """
+    raw = os.environ.get(AUTO_APPROVE_ENV_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "y"}
+
+
+def prompt_approval(exc: ApprovalRequired, *, yes: bool = False) -> bool:
+    """Decide whether to approve the gated op.
+
+    Decision order:
+
+    1. ``yes=True`` (CLI ``--yes`` flag) → silent yes.
+    2. ``DATAGROVE_AUTO_APPROVE=1`` env → silent yes.
+    3. Interactive: ask ``y/N`` on the shared console (stderr).
+       Default on Enter is **No** so a fat-fingered prompt doesn't
+       commit a 5-minute op.
+
+    Returns:
+        ``True`` if approved, ``False`` if declined.
+    """
+    if yes:
+        logger.info("auto-approving %s (--yes)", exc.cost.op_name)
+        return True
+    if is_auto_approve():
+        logger.info("auto-approving %s (%s=1)", exc.cost.op_name, AUTO_APPROVE_ENV_VAR)
+        return True
+
+    # Interactive prompt on the shared console (stderr, so --json on
+    # stdout still produces a parseable doc when the user types y).
+    console.print(
+        f"[yellow]Op {exc.cost.op_name!r} estimated at "
+        f"{exc.cost.est_seconds():.1f}s exceeds {exc.threshold_s:.1f}s approval threshold.[/yellow]"
+    )
+    answer = input("Proceed? [y/N]: ").strip().lower()
+    return answer in {"y", "yes"}
+
+
+def run_with_approval(
+    func: Callable[..., T],
+    *args: Any,
+    yes: bool = False,
+    **kwargs: Any,
+) -> T:
+    """Run ``func(*args, **kwargs)``; on :class:`ApprovalRequired`, prompt + retry.
+
+    ``func`` must accept an ``approve`` keyword (the gating contract).
+    The retry passes ``approve=True`` after a positive prompt; a
+    declined prompt re-raises :class:`ApprovalRequired` so callers can
+    convert to a non-zero exit code.
+
+    Examples:
+        >>> from datagrove.operations import OperationCost, gate
+        >>> from datagrove.cli.prompts import run_with_approval
+        >>> def heavy(*, approve=False):
+        ...     gate(OperationCost(op_name='demo', row_count=1), approve=approve)
+        ...     return 'ok'
+        >>> run_with_approval(heavy, yes=True)
+        'ok'
+    """
+    try:
+        return func(*args, **kwargs)
+    except ApprovalRequired as exc:
+        if prompt_approval(exc, yes=yes):
+            return func(*args, approve=True, **kwargs)
+        raise

--- a/packages/datagrove/datagrove/cli/render.py
+++ b/packages/datagrove/datagrove/cli/render.py
@@ -1,0 +1,128 @@
+"""Output helpers for CLI commands — rich console + structured JSON.
+
+Every CLI command renders through one of these helpers so the
+``--json`` contract is uniform: when ``json_out`` is True, we emit
+exactly one JSON document on stdout (no log noise, no progress bars);
+otherwise we render a rich panel/table to stderr-aware
+:class:`~rich.console.Console`.
+
+Why split rendering from the command body: agents calling the CLI via
+``--json`` parse a single document. Rules dropping log noise into the
+JSON stream would break them. Centralising the formatter here keeps
+the contract obvious — and Phase 4 task 4.7's approval prompts use
+the same console so prompts surface to a human even when ``--json``
+is set on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+__all__ = ["console", "render_dict", "render_issues", "render_table"]
+
+# A single shared Console so multiple commands look identical and
+# auto-detect notebook vs terminal once. ``stderr=True`` keeps prompts
+# + progress on stderr so ``--json`` on stdout stays parseable.
+console = Console(stderr=True)
+
+
+def render_dict(data: dict[str, Any], *, json_out: bool, title: str | None = None) -> None:
+    """Render a flat dict as a 2-column rich table OR a JSON document.
+
+    ``data`` values must be JSON-serialisable when ``json_out=True``.
+    The function emits to stdout for JSON (so it's pipeable) and to
+    stderr for rich (so it doesn't collide with --json on stdout).
+    """
+    if json_out:
+        # stdout, no trailing extras — agents parse a single document.
+        json.dump(data, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    table = Table(title=title, show_header=False)
+    table.add_column("key", style="bold cyan")
+    table.add_column("value")
+    for key, value in data.items():
+        table.add_row(str(key), str(value))
+    console.print(table)
+
+
+def render_table(rows: list[dict[str, Any]], *, json_out: bool, title: str | None = None) -> None:
+    """Render a list of homogeneous dicts as a rich table OR a JSON array.
+
+    Column order is taken from the first row. Empty input prints an
+    informational message in rich mode and ``[]`` in JSON mode.
+    """
+    if json_out:
+        json.dump(rows, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    if not rows:
+        console.print(f"[dim]{title or 'rows'}: (none)[/dim]")
+        return
+
+    table = Table(title=title)
+    for col in rows[0]:
+        table.add_column(str(col))
+    for row in rows:
+        table.add_row(*(str(row.get(c, "")) for c in rows[0]))
+    console.print(table)
+
+
+def render_issues(issues: list[Any], *, json_out: bool, header: str | None = None) -> None:
+    """Render a list of :class:`~datagrove.reports.Issue` records.
+
+    JSON mode emits the issues array (each issue via ``__dict__`` /
+    dataclass asdict-equivalent — :class:`Issue` is a dataclass so
+    ``vars(...)`` works). Rich mode prints a one-line-per-issue table
+    grouped by severity for at-a-glance reading.
+    """
+    if json_out:
+        # Each Issue is a frozen dataclass; vars() works on it.
+        payload = [_issue_to_payload(i) for i in issues]
+        json.dump({"header": header, "issues": payload}, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        return
+
+    if header:
+        console.print(f"[bold]{header}[/bold]")
+    if not issues:
+        console.print("[green]✓ no issues[/green]")
+        return
+    table = Table()
+    for col in ("severity", "code", "table", "row", "message"):
+        table.add_column(col)
+    for issue in issues:
+        table.add_row(
+            str(getattr(issue, "severity", "")),
+            str(getattr(issue, "code", "")),
+            str(getattr(issue, "table", "")),
+            str(getattr(issue, "row", "")),
+            str(getattr(issue, "message", "")),
+        )
+    console.print(table)
+
+
+def _issue_to_payload(issue: Any) -> dict[str, Any]:
+    """Flatten an :class:`~datagrove.reports.Issue` to a JSON-safe dict."""
+    fields = ("severity", "category", "code", "message", "table", "column", "row", "fix_hint", "extra")
+    return {f: _scalar(getattr(issue, f, None)) for f in fields}
+
+
+def _scalar(value: Any) -> Any:
+    """Convert StrEnum / Path / dataclass values into JSON-safe scalars."""
+    if value is None:
+        return None
+    if hasattr(value, "value"):  # StrEnum
+        return value.value
+    if isinstance(value, dict):
+        return {k: _scalar(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_scalar(v) for v in value]
+    return value

--- a/packages/datagrove/tests/cli/test_app.py
+++ b/packages/datagrove/tests/cli/test_app.py
@@ -1,0 +1,96 @@
+"""Tests for the generic datagrove CLI app (task 4.1a / issue #82).
+
+Uses typer's :class:`CliRunner` so every command is exercised end-to-end
+against the Leavenworth fixture. ``--json`` paths assert a single
+parseable document on stdout; rich paths only assert non-zero output
+(visual formatting is not pinned).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from datagrove.cli import build_app
+from gmnspy.fixtures import leavenworth
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def app():
+    """A fresh app per test so command-state can't leak between tests."""
+    return build_app()
+
+
+# ---------------------------------------------------------------------------
+# info
+# ---------------------------------------------------------------------------
+
+
+def test_info_rich_mode_runs(app):
+    """`info <fixture>` exits 0 and prints something on stderr (rich panel)."""
+    result = runner.invoke(app, ["info", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+
+
+def test_info_json_mode_emits_parseable_document(app):
+    """`info --json` writes a single JSON object on stdout with the expected keys."""
+    result = runner.invoke(app, ["info", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["table_count"] >= 1
+    assert {"name", "source", "engine", "table_count", "tables"} <= payload.keys()
+    # Each table summary has name + rows + columns.
+    assert all({"name", "rows", "columns"} <= t.keys() for t in payload["tables"])
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_json_mode_emits_issues_document(app):
+    """`validate --json` writes {header, issues: [...]} on stdout."""
+    result = runner.invoke(app, ["validate", "--json", str(leavenworth.csv_dir())])
+    # Leavenworth is clean per the spec; exit 0 expected.
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "header" in payload and "issues" in payload
+    assert isinstance(payload["issues"], list)
+
+
+def test_validate_rich_mode_runs(app):
+    """`validate` in rich mode exits 0 on Leavenworth and prints to stderr."""
+    result = runner.invoke(app, ["validate", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Help + arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_app_help_lists_commands(app):
+    """`--help` lists at least validate + info."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "validate" in result.stdout
+    assert "info" in result.stdout
+
+
+def test_unknown_command_exits_nonzero(app):
+    """Unknown subcommand exits non-zero (typer's standard behaviour)."""
+    result = runner.invoke(app, ["nope"])
+    assert result.exit_code != 0
+
+
+def test_build_app_returns_fresh_app_each_call():
+    """Two build_app() calls produce two distinct typer.Typer instances.
+
+    Important: gmnspy's CLI relies on getting its own copy so it can
+    register over commands without mutating the datagrove singleton.
+    """
+    a, b = build_app(), build_app()
+    assert a is not b

--- a/packages/datagrove/tests/cli/test_prompts.py
+++ b/packages/datagrove/tests/cli/test_prompts.py
@@ -1,0 +1,138 @@
+"""Tests for the CLI approval-prompt helpers (task 4.7 / issue #94)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from datagrove.cli.prompts import (
+    AUTO_APPROVE_ENV_VAR,
+    is_auto_approve,
+    prompt_approval,
+    run_with_approval,
+)
+from datagrove.operations import ApprovalRequired, OperationCost
+
+
+def _make_approval_required() -> ApprovalRequired:
+    """Build a realistic :class:`ApprovalRequired` to exercise prompt_approval / run_with_approval."""
+    cost = OperationCost(op_name="big_op", n_rows=10_000_000)  # ~ over default 180s budget
+    return ApprovalRequired(cost=cost, threshold_s=180.0)
+
+
+# ---------------------------------------------------------------------------
+# is_auto_approve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value,expected", [("1", True), ("true", True), ("YES", True), ("y", True)])
+def test_is_auto_approve_truthy_values(monkeypatch, value, expected):
+    """All four truthy spellings (case-insensitive) flip auto-approve on."""
+    monkeypatch.setenv(AUTO_APPROVE_ENV_VAR, value)
+    assert is_auto_approve() is expected
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "", "anything-else"])
+def test_is_auto_approve_falsy_values(monkeypatch, value):
+    """Non-truthy values (including unset) keep auto-approve off."""
+    monkeypatch.setenv(AUTO_APPROVE_ENV_VAR, value)
+    assert is_auto_approve() is False
+
+
+def test_is_auto_approve_unset(monkeypatch):
+    """Unset env var → False."""
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    assert is_auto_approve() is False
+
+
+# ---------------------------------------------------------------------------
+# prompt_approval
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_approval_yes_flag_short_circuits():
+    """yes=True skips both env + interactive checks."""
+    assert prompt_approval(_make_approval_required(), yes=True) is True
+
+
+def test_prompt_approval_env_short_circuits(monkeypatch):
+    """DATAGROVE_AUTO_APPROVE=1 skips the interactive prompt."""
+    monkeypatch.setenv(AUTO_APPROVE_ENV_VAR, "1")
+    assert prompt_approval(_make_approval_required()) is True
+
+
+def test_prompt_approval_interactive_no(monkeypatch):
+    """Default Enter (empty input) → False (don't run a 5-minute op by accident)."""
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    assert prompt_approval(_make_approval_required()) is False
+
+
+def test_prompt_approval_interactive_yes(monkeypatch):
+    """Typing 'y' returns True."""
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert prompt_approval(_make_approval_required()) is True
+
+
+# ---------------------------------------------------------------------------
+# run_with_approval
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_approval_passes_through_when_no_block():
+    """A function that never raises just runs normally."""
+    calls = {"n": 0}
+
+    def cheap(*, approve: bool = False) -> str:
+        calls["n"] += 1
+        return "done"
+
+    assert run_with_approval(cheap) == "done"
+    assert calls["n"] == 1
+
+
+def test_run_with_approval_retries_with_approve_true_after_yes(monkeypatch):
+    """First call raises ApprovalRequired, prompt says yes, retry succeeds with approve=True."""
+    state = {"first_call": True, "saw_approve": None}
+
+    def heavy(*, approve: bool = False) -> str:
+        if state["first_call"]:
+            state["first_call"] = False
+            raise _make_approval_required()
+        state["saw_approve"] = approve
+        return "done"
+
+    assert run_with_approval(heavy, yes=True) == "done"
+    assert state["saw_approve"] is True
+
+
+def test_run_with_approval_propagates_decline(monkeypatch):
+    """If the prompt is declined, ApprovalRequired propagates so callers can exit non-zero."""
+    monkeypatch.delenv(AUTO_APPROVE_ENV_VAR, raising=False)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+
+    def heavy(*, approve: bool = False) -> str:
+        raise _make_approval_required()
+
+    with pytest.raises(ApprovalRequired):
+        run_with_approval(heavy)
+
+
+def test_run_with_approval_forwards_args_and_kwargs():
+    """Positional + keyword arguments survive the wrapper unchanged."""
+
+    def fn(a, b, *, c, approve: bool = False) -> tuple:
+        return (a, b, c, approve)
+
+    assert run_with_approval(fn, 1, 2, c=3, yes=False) == (1, 2, 3, False)
+
+
+def test_auto_approve_env_var_name_is_namespaced():
+    """The env var lives under DATAGROVE_ — not GMNSPY_ — per architecture §6.1.
+
+    The namespace lives in datagrove because credential + approval
+    handling are generic concerns; gmnspy inherits without re-defining.
+    """
+    assert AUTO_APPROVE_ENV_VAR == "DATAGROVE_AUTO_APPROVE"
+    assert "GMNSPY" not in os.environ.get(AUTO_APPROVE_ENV_VAR, "_")

--- a/packages/gmnspy/gmnspy/cli/__init__.py
+++ b/packages/gmnspy/gmnspy/cli/__init__.py
@@ -1,1 +1,10 @@
-"""Typer-based CLI. Entry point: `gmnspy = gmnspy.cli.app:app`."""
+"""GMNS-aware CLI — extends :mod:`datagrove.cli` with GMNS commands.
+
+Entry point: ``gmnspy = gmnspy.cli.app:app``. Initial commands shipped
+in Phase 4 task 4.1b: GMNS-aware ``info``, ``quality``. Follow-up tasks
+add ``read``, ``spec``, ``clean``, ``index``.
+"""
+
+from .app import app
+
+__all__ = ["app"]

--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -1,0 +1,118 @@
+"""GMNS-aware CLI — extends :mod:`datagrove.cli.app` with GMNS commands.
+
+Entry point: ``gmnspy = gmnspy.cli.app:app``. Starts from
+:func:`datagrove.cli.app.build_app` (so users get every generic
+command — ``validate``, ``info``, …) then layers GMNS-specific ones
+on top:
+
+* ``info`` — GMNS-aware: prints :attr:`Network.spec_version` + the
+  named-table summary (links, nodes, segments, …) rather than the
+  generic resource list.
+* ``quality`` — runs the :mod:`gmnspy.quality` rule pack.
+
+Future Phase 4 tasks add ``read``, ``spec``, ``clean``, ``index`` per
+the architecture (tasks 4.3 / 4.6).
+
+Every command keeps the ``--json`` + ``--yes`` contract from
+:mod:`datagrove.cli` so an agent that learned the datagrove surface
+already knows the GMNS surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+from datagrove.cli.app import build_app
+from datagrove.cli.render import render_dict, render_issues
+from datagrove.quality import RuleConfig, run_quality
+
+from gmnspy import Network
+from gmnspy.quality import register_all
+
+__all__ = ["app"]
+
+logger = logging.getLogger(__name__)
+
+
+def _build_gmnspy_app() -> typer.Typer:
+    """Return the GMNS-aware typer app, layered on top of the datagrove generic app.
+
+    Pulled out as a private factory so tests can build a fresh app
+    rather than relying on the module-level singleton.
+    """
+    gmnspy_app = build_app()
+    # Stamp a gmnspy-flavoured help string over the datagrove default
+    # so ``gmnspy --help`` introduces itself correctly.
+    gmnspy_app.info.help = (
+        "gmnspy — GMNS network CLI. Inherits the generic datagrove commands "
+        "(validate, info) and adds GMNS-aware overrides + the data-quality "
+        "rule pack. Add --json to any command for machine-readable output."
+    )
+
+    # Replace the generic ``info`` with a GMNS-aware one. typer's
+    # second registration under the same name wins, so existing
+    # behaviour for end users is unchanged.
+    @gmnspy_app.command(name="info")
+    def gmns_info(
+        source: Path = typer.Argument(..., help="Path / URL to a GMNS network."),
+        spec_version: str = typer.Option(None, "--spec", help="Override the default GMNS spec version."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout instead of rich panels."),
+    ) -> None:
+        """Print GMNS-aware metadata about ``source`` — spec version + table summary."""
+        net = Network.from_source(source, spec_version=spec_version)
+        data = {
+            "name": net.spec.name,
+            "source": str(source),
+            "spec_version": net.spec_version,
+            "engine": type(net.engine).__name__,
+            "links": _safe_count(net, "link"),
+            "nodes": _safe_count(net, "node"),
+            "table_count": len(net.tables),
+            "tables": sorted(net.tables.keys()),
+        }
+        render_dict(data, json_out=json_out, title=f"gmnspy info: {source}")
+
+    @gmnspy_app.command(name="quality")
+    def quality_cmd(
+        source: Path = typer.Argument(..., help="Path / URL to a GMNS network."),
+        spec_version: str = typer.Option(None, "--spec", help="Override the default GMNS spec version."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout instead of rich panels."),
+    ) -> None:
+        """Run the GMNS data-quality rule pack against ``source``.
+
+        Each rule emits Severity.WARNING / INFO findings with category
+        DATA_QUALITY. The output is a ValidationReport (rendered as a
+        rich table or JSON document per ``--json``).
+        """
+        # Ensure rules are registered even when the entry point isn't
+        # picked up (e.g. editable installs that skipped re-install).
+        register_all()
+        net = Network.from_source(source, spec_version=spec_version)
+        report = run_quality(net, config={code: RuleConfig() for code in []})
+        render_issues(report.issues, json_out=json_out, header=f"quality report: {source}")
+        # Quality issues are WARNING/INFO by default — never exit non-zero
+        # from this command. Callers wanting hard fail use --json + check
+        # for non-empty issues themselves.
+
+    return gmnspy_app
+
+
+def _safe_count(net: Network, table_name: str) -> int | None:
+    """Return ``net.tables[table_name].count()`` or ``None`` if the table is absent."""
+    table = net.tables.get(table_name)
+    if table is None:
+        return None
+    try:
+        return table.count()
+    except Exception:  # pragma: no cover - best effort for `info`
+        return None
+
+
+# Module-level app for the `gmnspy` console-script entry point.
+app = _build_gmnspy_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke
+    app()

--- a/packages/gmnspy/tests/test_cli.py
+++ b/packages/gmnspy/tests/test_cli.py
@@ -1,0 +1,92 @@
+"""Tests for the GMNS-aware CLI (task 4.1b / issue #83).
+
+Exercises the extended ``info`` (overrides datagrove's generic with a
+GMNS-aware version) + the new ``quality`` command. Reuses datagrove's
+:class:`CliRunner` infra; both ``--json`` and rich output paths
+exercised.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gmnspy.cli.app import app
+from gmnspy.fixtures import leavenworth
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# info — GMNS-aware override
+# ---------------------------------------------------------------------------
+
+
+def test_gmns_info_json_includes_spec_version():
+    """gmnspy info --json carries spec_version + link/node counts."""
+    result = runner.invoke(app, ["info", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["spec_version"] == "0.97"
+    assert isinstance(payload["links"], int) and payload["links"] > 0
+    assert isinstance(payload["nodes"], int) and payload["nodes"] > 0
+
+
+def test_gmns_info_respects_spec_override():
+    """--spec 0.96 stamps a different spec_version on the output."""
+    result = runner.invoke(app, ["info", "--json", "--spec", "0.96", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["spec_version"] == "0.96"
+
+
+def test_gmns_info_rich_runs():
+    """Rich-mode info exits 0 and writes to stderr."""
+    result = runner.invoke(app, ["info", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# quality
+# ---------------------------------------------------------------------------
+
+
+def test_quality_json_emits_issues_document():
+    """gmnspy quality --json writes {header, issues: [...]} on stdout."""
+    result = runner.invoke(app, ["quality", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "issues" in payload
+    # All emitted issues should be DATA_QUALITY category.
+    assert all(i["category"] == "data_quality" for i in payload["issues"])
+    # Leavenworth's residential streets at 40 mph fire the high-speed rule.
+    codes = {i["code"] for i in payload["issues"]}
+    assert "quality.high_speed_residential" in codes
+
+
+def test_quality_never_exits_nonzero_on_warnings_only():
+    """quality findings are WARNING/INFO — command exit stays 0 even with issues."""
+    result = runner.invoke(app, ["quality", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Help + generic commands still present
+# ---------------------------------------------------------------------------
+
+
+def test_app_help_lists_gmns_and_generic_commands():
+    """`gmnspy --help` shows the generic (info, validate) + GMNS (quality) commands."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "info" in result.stdout
+    assert "validate" in result.stdout
+    assert "quality" in result.stdout
+
+
+def test_generic_validate_still_works_under_gmnspy():
+    """The inherited datagrove `validate` command still works on a GMNS network."""
+    result = runner.invoke(app, ["validate", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "issues" in payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ convention = "google"
 "**/tests/**" = ["D"]
 "**/__init__.py" = ["D"]
 "scripts/**" = ["E501", "D"]  # scripts have long inline strings + don't need full docstrings
+# Typer CLI command signatures use `typer.Argument(...)` / `typer.Option(...)`
+# in argument defaults — that's the idiomatic typer API. B008 (function call
+# in default) is a false positive for this pattern, scoped to cli/ paths only.
+"**/cli/**" = ["B008"]
 
 # ---------------------------------------------------------------------------
 # Pyright (strict on datagrove; standard on gmnspy)


### PR DESCRIPTION
## Summary

Phase 4 Wave 1 — three tasks shipped together because they share the typer surface and need to land as one for any of them to be useful.

| Task | What |
|---|---|
| **#82** (4.1a) | `datagrove.cli` — `build_app()` factory + `validate` + `info` commands + render helpers. |
| **#83** (4.1b) | `gmnspy.cli` — extends `build_app()` with GMNS-aware `info` (overrides) + `quality`. |
| **#89** (4.7) | `datagrove.cli.prompts` — `run_with_approval` wrapper + `--yes` / `DATAGROVE_AUTO_APPROVE=1` channels. |

### Design

- **One factory, two CLIs.** `build_app()` returns a fresh `typer.Typer` so the `datagrove` and `gmnspy` console scripts compose on the same foundation. typer's "second registration under the same name wins" lets gmnspy override `info` with the GMNS-aware version without touching the datagrove module.
- **Uniform `--json` contract.** Every command honours `--json` and writes exactly one parseable document on stdout. Rich panels go to stderr so they don't pollute the JSON stream. Agents calling via `--json` get a single document; humans get rich output.
- **Approval-gating channels** in priority: `--yes` flag → `DATAGROVE_AUTO_APPROVE=1` env → interactive y/N (default No). The env var is namespaced `DATAGROVE_` per architecture §6.1 — credentials + approval are generic concerns that gmnspy inherits.
- **Shared rich Console on stderr.** Single instance so commands look identical and prompts surface even when `--json` is set on stdout.

### Cosmetic touch

`gmnspy --help` overrides the inherited help string so it introduces itself as "gmnspy — GMNS network CLI" rather than the datagrove default.

### Lint config

Added `"**/cli/**" = ["B008"]` per-file ignore: typer's idiomatic API puts `typer.Argument(...)` in argument defaults, which trips bugbear's "function call in default" rule. Scoped to cli/ paths only.

## Test plan

- [x] 33 new tests across `packages/datagrove/tests/cli/test_app.py`, `test_prompts.py`, and `packages/gmnspy/tests/test_cli.py`.
- [x] End-to-end smoke: `gmnspy info --json packages/.../leavenworth/csv` produces a parseable document with `spec_version`, `links`, `nodes`, etc.
- [x] Full suite: **747 → 780 passing**.
- [x] `ruff check` / `ruff format --check` / `lint-imports` / `lint_no_sql` all clean.

## What this unblocks

Wave 2 leaf-task dispatch: `convert` (4.2), `spec sync/list/diff` (4.3), `bench` (4.4), `doctor` (4.5), and the Skills + migration guide. All extend this typer foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)