### PR TITLE
feat(cli): datagrove convert (#84)

### DIFF
--- a/packages/datagrove/datagrove/cli/app.py
+++ b/packages/datagrove/datagrove/cli/app.py
@@ -94,7 +94,125 @@ def build_app() -> typer.Typer:
         }
         render_dict(data, json_out=json_out, title=f"info: {source}")
 
+    @typer_app.command(name="convert")
+    def convert(
+        source: Path = typer.Argument(..., help="Source data package path/URL."),
+        dest: Path = typer.Argument(..., help="Destination path."),
+        fmt: str = typer.Option(
+            None,
+            "--format",
+            "-f",
+            help="Output format (csv/parquet/duckdb/zipcsv). Default: infer from dest extension; fall back to parquet.",
+        ),
+        engine: str = typer.Option(
+            None,
+            "--engine",
+            help="Engine: ibis/pandas/polars. Default: ibis.",
+        ),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Auto-approve gated ops."),
+    ) -> None:
+        """Convert a data package from any supported format to another.
+
+        Loads ``source`` (any format datagrove can read) and writes the
+        same logical package to ``dest`` in the target format. Output
+        format is taken from ``--format`` when supplied, otherwise
+        inferred from the ``dest`` extension; an extension-less ``dest``
+        defaults to partitioned parquet (architecture §6.1).
+        """
+        resolved_engine = _resolve_engine(engine)
+        package = Package.from_source(source, engine=resolved_engine)
+
+        # Wrap the write through run_with_approval so a cost-model gate
+        # on a large conversion surfaces as a prompt instead of an
+        # uncaught exception. ``Package.write`` doesn't currently raise
+        # ApprovalRequired itself, but routing through the helper keeps
+        # the gating seam in place for when it grows one.
+        try:
+            run_with_approval(package.write, dest, format=fmt, yes=yes)
+        except ApprovalRequired:
+            console.print("[yellow]conversion declined — exiting 1.[/yellow]")
+            raise typer.Exit(code=1) from None
+
+        # Resolve the effective format for the summary — mirror the
+        # inference Package.write just did so callers can read it back.
+        effective_format = fmt or _infer_format_for_summary(dest)
+        total_rows = 0
+        for table in package.tables.values():
+            try:
+                total_rows += int(table.count())
+            except Exception as exc:  # pragma: no cover - per-table resilience
+                logger.warning("convert: could not count rows for %r — %s", table.name, exc)
+
+        summary = {
+            "source": str(source),
+            "dest": str(dest),
+            "format": effective_format,
+            "engine": type(resolved_engine).__name__,
+            "table_count": len(package.tables),
+            "total_rows": total_rows,
+        }
+        render_dict(summary, json_out=json_out, title=f"convert: {source} → {dest}")
+
     return typer_app
+
+
+def _resolve_engine(name: str | None):
+    """Resolve ``--engine`` flag to an :class:`~datagrove.engines.base.Engine`.
+
+    ``None`` returns the registry default (currently ibis). Explicit
+    names are case-insensitive and import the relevant engine lazily so
+    the CLI startup stays cheap when only one engine is in use.
+
+    Raises:
+        typer.BadParameter: when ``name`` is not one of the supported
+            engines — the CLI surfaces this as a non-zero exit with a
+            helpful message rather than a stack trace.
+    """
+    from datagrove.engines import get_engine
+
+    if name is None:
+        return get_engine()
+    name = name.lower()
+    if name == "ibis":
+        from datagrove.engines.ibis_engine import IbisEngine
+
+        return IbisEngine()
+    if name == "pandas":
+        from datagrove.engines.pandas_engine import PandasEngine
+
+        return PandasEngine()
+    if name == "polars":
+        from datagrove.engines.polars_engine import PolarsEngine
+
+        return PolarsEngine()
+    raise typer.BadParameter(f"unknown engine {name!r}; expected ibis/pandas/polars")
+
+
+def _infer_format_for_summary(dest: Path) -> str:
+    """Best-effort format name for the convert summary dict.
+
+    Mirrors :func:`datagrove.dataset.package._infer_write_format` so the
+    summary shows the same format ``Package.write`` actually used. We
+    re-implement the dispatch here (rather than importing the private
+    helper) to keep the CLI → dataset edge clean; the rules are short
+    and identical to the writer's: extension wins, no-extension
+    defaults to parquet, unknown extension falls back to ``"unknown"``
+    in the summary (the write itself would have raised before we got
+    here).
+    """
+    name = dest.name.lower()
+    if name.endswith(".duckdb"):
+        return "duckdb"
+    if name.endswith(".csv.zip"):
+        return "zipcsv"
+    if name.endswith(".parquet"):
+        return "parquet"
+    if name.endswith(".csv"):
+        return "csv"
+    if "." not in name:
+        return "parquet"
+    return "unknown"
 
 
 def _table_summary(package: Package) -> list[dict]:

--- a/packages/datagrove/tests/cli/test_convert.py
+++ b/packages/datagrove/tests/cli/test_convert.py
@@ -1,0 +1,129 @@
+"""Tests for ``datagrove convert`` (task 4.2 / issue #84).
+
+End-to-end exercises the convert command through typer's
+:class:`CliRunner` against the Leavenworth fixture. The roundtrip test
+is the load-bearing one — it proves the CSV → parquet write produces a
+package datagrove can read back with the same logical table set. The
+remaining tests pin the format-inference / flag-parsing behaviours so a
+later refactor of those rules can't silently drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from datagrove.cli import build_app
+from datagrove.dataset import Package
+from gmnspy.fixtures import leavenworth
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def app():
+    """A fresh app per test so command-state can't leak between tests."""
+    return build_app()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_convert_csv_to_parquet_roundtrip(app, tmp_path: Path):
+    """Convert the Leavenworth CSV dir to a parquet dir, then read it back.
+
+    The round-trip is the contract: after a convert we expect to be
+    able to ``Package.from_source`` the destination and recover the
+    same set of table names.
+    """
+    src = leavenworth.csv_dir()
+    dest = tmp_path / "leavenworth.parquet"
+
+    result = runner.invoke(app, ["convert", str(src), str(dest)])
+    assert result.exit_code == 0, result.stderr
+    assert dest.exists(), "convert did not create the destination directory"
+
+    # Read the source + the destination and compare table inventories.
+    src_pkg = Package.from_source(src)
+    dest_pkg = Package.from_source(dest)
+    assert set(dest_pkg.keys()) == set(src_pkg.keys())
+    assert len(dest_pkg.keys()) >= 1
+
+
+# ---------------------------------------------------------------------------
+# --json summary
+# ---------------------------------------------------------------------------
+
+
+def test_convert_json_mode_emits_summary(app, tmp_path: Path):
+    """``--json`` writes a single parseable summary dict on stdout."""
+    src = leavenworth.csv_dir()
+    dest = tmp_path / "out.parquet"
+
+    result = runner.invoke(app, ["convert", "--json", str(src), str(dest)])
+    assert result.exit_code == 0, result.stderr
+
+    payload = json.loads(result.stdout)
+    assert {"source", "dest", "format", "table_count"} <= payload.keys()
+    assert payload["table_count"] >= 1
+    assert payload["format"] == "parquet"
+
+
+# ---------------------------------------------------------------------------
+# Format inference + override
+# ---------------------------------------------------------------------------
+
+
+def test_convert_format_inferred_from_extension(app, tmp_path: Path):
+    """``dest=foo.parquet`` infers parquet without an explicit ``--format``."""
+    src = leavenworth.csv_dir()
+    dest = tmp_path / "inferred.parquet"
+
+    result = runner.invoke(app, ["convert", "--json", str(src), str(dest)])
+    assert result.exit_code == 0, result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload["format"] == "parquet"
+    assert dest.exists()
+
+
+def test_convert_explicit_format_overrides_extension(app, tmp_path: Path):
+    """``--format csv`` wins over a ``.parquet`` extension."""
+    src = leavenworth.csv_dir()
+    # Suffix says parquet but the explicit flag should force CSV.
+    dest = tmp_path / "override.parquet"
+
+    result = runner.invoke(app, ["convert", "--json", "--format", "csv", str(src), str(dest)])
+    assert result.exit_code == 0, result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload["format"] == "csv"
+    # The directory exists and contains .csv files — never .parquet.
+    assert dest.exists()
+    children = list(dest.iterdir())
+    assert children, "csv convert produced no files"
+    assert any(c.suffix == ".csv" for c in children)
+    assert not any(c.suffix == ".parquet" for c in children)
+
+
+# ---------------------------------------------------------------------------
+# Engine flag
+# ---------------------------------------------------------------------------
+
+
+def test_convert_rejects_unknown_engine(app, tmp_path: Path):
+    """``--engine bogus`` exits non-zero with a helpful message."""
+    src = leavenworth.csv_dir()
+    dest = tmp_path / "wont-exist.parquet"
+
+    result = runner.invoke(app, ["convert", "--engine", "bogus", str(src), str(dest)])
+    assert result.exit_code != 0
+    # typer.BadParameter surfaces on stderr; check the engine name and
+    # the expected-values blurb both appear.
+    combined = (result.stderr or "") + (result.stdout or "") + str(result.exception or "")
+    assert "bogus" in combined
+    assert "ibis" in combined or "pandas" in combined or "polars" in combined


### PR DESCRIPTION
## Summary

Ships `datagrove convert` — the third command on the typer foundation merged in 4.1a, alongside `validate` and `info`.

- Loads a source package via `Package.from_source(source, engine=...)` and writes through `Package.write(dest, format=...)`. Format dispatch goes through `datagrove.io` adapters (csv / parquet / duckdb / zipcsv) so adding a format auto-wires to convert.
- `--engine` (ibis/pandas/polars, default ibis) selects the materialisation engine; unknown engines surface as `typer.BadParameter` with a non-zero exit.
- `--format` overrides extension inference; an extension-less dest defaults to partitioned parquet (architecture §6.1).
- The write is wrapped in `run_with_approval` so a future cost-model gate on a large conversion will prompt (and respect `--yes` / `DATAGROVE_AUTO_APPROVE=1`) instead of crashing.
- `--json` emits a single summary dict on stdout (`source`, `dest`, `format`, `engine`, `table_count`, `total_rows`) for agent consumption.

Closes #84.

## Test plan

- [x] `test_convert_csv_to_parquet_roundtrip` — Leavenworth CSV → parquet, then `Package.from_source` the result and confirm table names round-trip.
- [x] `test_convert_json_mode_emits_summary` — `--json` is a single parseable dict with the documented keys.
- [x] `test_convert_format_inferred_from_extension` — `foo.parquet` infers parquet without `--format`.
- [x] `test_convert_explicit_format_overrides_extension` — `--format csv` wins over a `.parquet` suffix; output directory contains `.csv` files only.
- [x] `test_convert_rejects_unknown_engine` — `--engine bogus` exits non-zero with the engine name and the expected-values blurb in the message.
- [x] Full suite: 785 passed (was 780 → +5), 48 skipped (polars not installed in this env), 0 failed.
- [x] `ruff check`, `ruff format --check`, `lint-imports`, `scripts/lint_no_sql.py` all clean.

## Deferred (not in scope per the brief)

- Partitioned parquet H3/zone layout — `Package.write` produces a flat per-table parquet dir today.
- Streaming conversion for huge sources — cost-model gate will catch them once a write-side gate lands.
- `--scope` flag (deferred to its own issue).

Do not merge — orchestrator will handle integration with the other 4.x branches.

Generated with [Claude Code](https://claude.com/claude-code)