### PR TITLE
docs(migration): v0.3 to v1.0 migration guide (#97)

### DIFF
--- a/docs/migration/v0.3-to-v1.0.md
+++ b/docs/migration/v0.3-to-v1.0.md
@@ -1,0 +1,199 @@
+# Migrating from GMNSpy v0.3.x to v1.0
+
+GMNSpy v1.0 is a ground-up rewrite. The public API, package layout, and
+runtime engine all changed. This guide walks v0.3.5 users through the
+breaking changes and shows the new equivalents.
+
+If you need the old behavior, pin `gmnspy<1.0` in your requirements —
+v0.3.5 will remain on PyPI but is no longer maintained.
+
+## TL;DR
+
+- v1.0 is a clean rewrite — **no automatic upgrade path, no compat shim,
+  no `DeprecationWarning` bridges**. You will edit your imports.
+- The codebase is split into two PyPI packages: **`datagrove`** (generic
+  schema / validation / IO engine) and **`gmnspy`** (GMNS-specific
+  bindings on top).
+- Old: `import gmnspy; gmnspy.read_gmns_network(path)` →
+  New: `from gmnspy import Network; Network.from_source(path)`.
+- Validation returns a single `ValidationReport` — multiple renderers
+  (rich terminal / JSON / HTML) replace ad-hoc `_check_*` helpers.
+- Memory + performance are first-class: **lazy ibis is the default
+  engine**, with optional pandas / polars / duckdb backends. Use
+  `.to_pandas()` / `.to_polars()` only when you actually need the
+  materialized frame.
+- New **CLI**: `gmnspy validate`, `gmnspy info`, `gmnspy quality`, and
+  the inherited `datagrove` commands. Every command supports `--json`
+  for AI / scripting consumption.
+
+## Installation
+
+**v0.3.x**
+
+```bash
+pip install gmnspy
+```
+
+**v1.0**
+
+```bash
+pip install datagrove gmnspy
+```
+
+`gmnspy` depends on `datagrove`, so you can also install just `gmnspy`
+and pull `datagrove` transitively — listing both is recommended so the
+intent is explicit in your lockfile.
+
+## API mapping
+
+| v0.3 (removed) | v1.0 (use this) | Notes |
+|---|---|---|
+| `import gmnspy` | `from gmnspy import Network` | Top-level helpers are gone — the entry point is the `Network` class. |
+| `gmnspy.read_gmns_network(path)` | `gmnspy.Network.from_source(path)` | Returns a `Network` (subclass of `datagrove.Package`) with lazy tables, not a `dict[str, DataFrame]`. |
+| `gmnspy.read_gmns_csv(path, validate=True)` | `datagrove.read(path)` for any table; or `Network.from_source(dir).<table>` | Format inference (csv / parquet / duckdb / zip-csv / URL) is automatic. |
+| `gmnspy.validation.apply_schema_to_df(df, schema_file=...)` | `net.validate()` | Schema, foreign-key, structural, and sync-state checks all run from one call. |
+| `gmnspy.validation.validate_foreign_keys(...)` | `net.validate()` then filter `report.issues` by `rule="foreign_key"` | Composite + self-referential FKs supported. |
+| `gmnspy.validation._check_*` helpers | `report = net.validate(); report.issues` / `report.summary()` | The Series-vs-bool truthiness bugs in `constraint_checking.py` are gone — predicates are ibis expressions now. |
+| `gmnspy.schema.read_schema(path)` | `datagrove.spec.load_spec(path)` / `gmnspy.load_gmns_spec(version="0.97")` | Multi-version spec support; `DEFAULT_SPEC = "0.97"`. |
+| `gmnspy.schema.read_config(config_file, data_dir, schema_dir)` | `Network.from_source(path)` (auto-discovery) or `datagrove.Package.from_config(...)` | No more manual config wiring for the common case. |
+| `gmnspy.schema.document_schemas_to_md(...)` | `datagrove.docgen.spec_to_md(spec)` | Same idea, generalized; honors version selection. |
+| `gmnspy.utils.logger` | `import logging; logging.getLogger("gmnspy")` | The `utils` grab-bag is gone. |
+| `gmnspy.utils.list_to_md_table` | `datagrove.utils.markdown.list_to_table` | Moved to `datagrove`. |
+| (no CLI) | `gmnspy validate <path>` / `gmnspy info <path>` / `gmnspy quality <path>` / `datagrove validate <path>` | All commands accept `--json` and `--yes`. |
+| (no editing API) | `with datagrove.editing.Session(net) as s: gmnspy.clean.simplify_geometry(net, s)` | Atomic rollback + audit log. |
+| (no network-aware scope) | `gmnspy.scope.from_nodes(net, [...], path_between=True).apply()` | Network buffer, spatial buffer, connected component, zone filter — all chainable. |
+
+## What's gone (no replacement)
+
+These v0.3 surfaces were removed because they were either unsound or
+subsumed by the new engine:
+
+- **`gmnspy.validation.constraint_checking`** — the per-row validators
+  there had latent Series-vs-bool truthiness bugs (`if some_series:`)
+  that silently passed. Replaced by ibis-first predicates evaluated on
+  pyarrow samples; the failure mode is structurally impossible.
+- **`gmnspy.utils`** — split across `datagrove.utils` (generic helpers)
+  and `gmnspy.semantics` (GMNS-specific name handling).
+- **Implicit `pandas` everywhere.** Tables are lazy ibis expressions by
+  default. If you mutated a returned DataFrame in v0.3 expecting the
+  change to stick on the network, you must now go through an editing
+  `Session` (see below).
+- **`read_gmns_network` returning a bare dict.** The `Network` object
+  exposes the same tables as attributes (`net.nodes`, `net.links`, …)
+  but those attributes return lazy `Table` wrappers, not DataFrames.
+
+## What's new
+
+- **Modern formats out of the box.** Parquet (incl. partitioned),
+  DuckDB, zip-CSV, and HTTP(S) URLs with a credentials cascade. Try
+  `datagrove.read("s3://bucket/network.parquet", credentials=...)`.
+- **Multi-version GMNS spec.** v0.95 / v0.96 / v0.97 ship side-by-side;
+  default is 0.97. Per-call override:
+  `Network.from_source(path, spec_version="0.96")`.
+- **Network-aware scoping.** BFS, Dijkstra network buffer, spatial
+  buffer from any link / point / node, connected-component, zone
+  filter — chainable. See `gmnspy.scope`.
+- **Data-quality framework.** 7 GMNS rules out of the box; plugin
+  pattern for custom rules. Surface: `gmnspy quality <path>`.
+- **Editing with rollback.** `gmnspy.clean.simplify_geometry`,
+  `merge_close_nodes`, `remove_orphans`, `recompute_lengths`. All run
+  inside an atomic `datagrove.editing.Session` with an audit log.
+- **CLI + AI surface.** `gmnspy --help`. Every command takes `--json`
+  for machine-readable output. (MCP server lands in #91 / #92.)
+- **Reports.** `report.to_html(path)` / `report.to_json()` /
+  `report.to_rich()` render the same `ValidationReport` for humans,
+  CI, or dashboards.
+
+## Worked example: load + validate + filter a network
+
+**v0.3.5**
+
+```python
+import gmnspy
+import pandas as pd
+
+# Load — returns a dict[str, DataFrame], validates eagerly
+network = gmnspy.read_gmns_network("path/to/gmns/dir")
+
+nodes = network["node"]
+links = network["link"]
+
+# Re-validate one table by hand
+gmnspy.validation.apply_schema_to_df(
+    nodes,
+    schema_file="gmnspy/spec/node.schema.json",
+    originating_file="node.csv",
+)
+
+# Filter to a subnetwork — pandas only, no FK awareness
+keep = nodes[nodes["zone_id"] == 42]["node_id"]
+sub_links = links[links["from_node_id"].isin(keep) & links["to_node_id"].isin(keep)]
+```
+
+**v1.0**
+
+```python
+from gmnspy import Network
+from gmnspy import scope
+
+# Load — lazy, format-agnostic, no eager validation
+net = Network.from_source("path/to/gmns/dir")  # or .parquet / .duckdb / URL
+
+# Validate everything (schema + FK + structural + sync-state) in one call
+report = net.validate()
+if not report.ok:
+    report.to_rich()           # pretty-print to terminal
+    report.to_html("report.html")
+    raise SystemExit(1)
+
+# Network-aware subnetwork: zone filter, then connected component
+sub = (
+    scope.from_zones(net, [42])
+    .connected_component()
+    .apply()
+)
+
+# Materialize only when you need to
+nodes_df = sub.nodes.to_pandas()
+```
+
+Equivalent from the shell:
+
+```bash
+gmnspy validate path/to/gmns/dir --json > report.json
+gmnspy info     path/to/gmns/dir
+gmnspy quality  path/to/gmns/dir --json
+```
+
+## Breaking changes checklist
+
+Before you upgrade, scan your codebase for each of these:
+
+- [ ] All `from gmnspy import …` and `from gmnspy.* import …` imports
+      refactored — submodule paths changed.
+- [ ] Calls to `read_gmns_csv` / `read_gmns_network` replaced with
+      `Network.from_source(...)` (or `datagrove.read(...)` for a single
+      table).
+- [ ] Code that mutated returned DataFrames in place now uses
+      `datagrove.editing.Session` (or explicitly materializes with
+      `.to_pandas()` and treats the result as a snapshot).
+- [ ] Validation call sites updated — they receive a
+      `ValidationReport`, not bare lists or `None`. Check `report.ok`
+      / iterate `report.issues`.
+- [ ] Tests that imported `gmnspy.validation._check_*` helpers switch
+      to `Network.validate()` (or `datagrove.Package.validate()` for
+      non-GMNS packages).
+- [ ] `gmnspy.utils` imports rerouted: logger → stdlib `logging`,
+      markdown helpers → `datagrove.utils.markdown`.
+- [ ] Hard-coded references to `gmnspy/spec/*.schema.json` paths
+      replaced with `gmnspy.load_gmns_spec(version=...)` or
+      `gmnspy.get_spec_path(version=...)`.
+
+## Where to ask
+
+- **Issues:** <https://github.com/e-lo/GMNSpy/issues>
+- **Discussions:** <https://github.com/e-lo/GMNSpy/discussions>
+- **v1.0 tracking issue:** <https://github.com/e-lo/GMNSpy/issues/97>
+
+If you hit a v0.3 pattern not covered above, please open an issue with
+the snippet — we want this guide to cover the long tail.


### PR DESCRIPTION
## Summary

- Adds `docs/migration/v0.3-to-v1.0.md` (199 lines) — the upgrade guide for v0.3.5 users coming to v1.0.
- Acknowledges the clean break (no compat shim, no `DeprecationWarning` bridge) and the `datagrove` + `gmnspy` two-package split.
- Old → new API mapping table covers the common v0.3 call sites: `read_gmns_network`, `read_gmns_csv`, `apply_schema_to_df`, validation helpers, `gmnspy.utils`, and the schema/config loaders.
- Documents removals without replacement (the `constraint_checking` Series-vs-bool bugs, the `utils` grab-bag, implicit pandas) and v1.0 additions (multi-version spec, `scope`, `quality`, `editing`, CLI with `--json`).
- Includes a side-by-side worked example (load + validate + filter) and a breaking-changes checklist.

Closes #97.

## Test plan

- [ ] Render the page in mkdocs locally and confirm tables + code blocks display correctly.
- [ ] Spot-check the API mapping against the current `Network` / `datagrove.Package` surface before tagging v1.0.
- [ ] Confirm cross-links (issues #91 / #92 for MCP, #97 for tracking) resolve once v1.0 ships.

Generated with [Claude Code](https://claude.com/claude-code)