### PR TITLE
feat(cli): gmnspy bench (#86)

### DIFF
--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -96,7 +96,86 @@ def _build_gmnspy_app() -> typer.Typer:
         # from this command. Callers wanting hard fail use --json + check
         # for non-empty issues themselves.
 
+    @gmnspy_app.command(name="bench")
+    def bench(
+        source: Path = typer.Argument(..., help="Path/URL to a GMNS network."),
+        engine: str = typer.Option(None, "--engine", help="ibis/pandas/polars (default: ibis)."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Run read/validate/connectivity benchmarks; print timings.
+
+        Phases timed (each via time.perf_counter):
+
+        * ``load`` — :meth:`Network.from_source`.
+        * ``validate`` — :meth:`Network.validate` (structural/schema only).
+        * ``links_count`` + ``nodes_count`` — trivial materialisation sanity.
+        * ``is_connected`` — full graph index build + component count
+          (skipped silently when the ``[clean]`` extra is missing).
+
+        Output is a dict with ``phases`` (list of ``{phase, seconds}``) and
+        a ``total_seconds`` summary. ``--json`` writes the dict to stdout for
+        machine consumption; otherwise rendered via the standard rich panel.
+        """
+        import time
+
+        eng = _resolve_engine(engine)
+
+        timings: list[dict] = []
+
+        def _time(phase: str, fn):
+            t0 = time.perf_counter()
+            result = fn()
+            timings.append({"phase": phase, "seconds": round(time.perf_counter() - t0, 4)})
+            return result
+
+        net = _time("load", lambda: Network.from_source(source, engine=eng))
+        _time("validate", lambda: net.validate(foreign_keys=False, sync_state=False))
+        _time("links_count", lambda: net.links.count())
+        _time("nodes_count", lambda: net.nodes.count())
+        # Connectivity needs the [clean] extra (igraph). Skip silently if not available.
+        try:
+            from gmnspy.semantics import is_connected
+
+            _time("is_connected", lambda: is_connected(net))
+        except ImportError:
+            timings.append({"phase": "is_connected", "seconds": None, "skipped": "igraph not installed"})
+
+        total = round(sum(t["seconds"] for t in timings if t.get("seconds") is not None), 4)
+        data = {
+            "source": str(source),
+            "engine": type(eng).__name__,
+            "total_seconds": total,
+            "phases": timings,
+        }
+        render_dict(data, json_out=json_out, title=f"bench: {source}")
+
     return gmnspy_app
+
+
+def _resolve_engine(name: str | None):
+    """Resolve an engine by name (``ibis`` / ``pandas`` / ``polars``).
+
+    Mirrors the helper used by other Phase-4 commands; kept local so this
+    module doesn't depend on the 4.2 helper landing first.
+    """
+    from datagrove.engines import get_engine
+
+    if name is None:
+        return get_engine()
+    name = name.lower()
+    if name == "ibis":
+        from datagrove.engines.ibis_engine import IbisEngine
+
+        return IbisEngine()
+    if name == "pandas":
+        from datagrove.engines.pandas_engine import PandasEngine
+
+        return PandasEngine()
+    if name == "polars":
+        from datagrove.engines.polars_engine import PolarsEngine
+
+        return PolarsEngine()
+    raise typer.BadParameter(f"unknown engine {name!r}")
 
 
 def _safe_count(net: Network, table_name: str) -> int | None:

--- a/packages/gmnspy/tests/test_cli_bench.py
+++ b/packages/gmnspy/tests/test_cli_bench.py
@@ -1,0 +1,57 @@
+"""Tests for ``gmnspy bench`` (task 4.4 / issue #86).
+
+Smoke-level coverage — the command's contract is a stable JSON shape
+(``total_seconds`` + per-phase ``seconds``) that downstream CI bench
+workflows can diff against. We don't assert on wall-clock numbers
+(noisy across runners); we just check the shape + exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gmnspy.cli.app import app
+from gmnspy.fixtures import leavenworth
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_bench_runs_on_leavenworth():
+    """bench --json on the Leavenworth fixture exits 0 with ``total_seconds`` + >=4 phases."""
+    result = runner.invoke(app, ["bench", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "total_seconds" in payload
+    assert isinstance(payload["total_seconds"], (int, float))
+    assert "phases" in payload
+    assert len(payload["phases"]) >= 4
+    # Required phases are present in order.
+    names = [p["phase"] for p in payload["phases"]]
+    for expected in ("load", "validate", "links_count", "nodes_count"):
+        assert expected in names
+
+
+def test_bench_json_phases_have_numeric_seconds():
+    """Every non-skipped phase reports ``seconds`` as a number."""
+    result = runner.invoke(app, ["bench", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    for phase in payload["phases"]:
+        if phase.get("skipped"):
+            assert phase["seconds"] is None
+            continue
+        assert isinstance(phase["seconds"], (int, float))
+        assert phase["seconds"] >= 0.0
+
+
+def test_bench_rejects_unknown_engine():
+    """``--engine bogus`` exits non-zero (typer.BadParameter)."""
+    result = runner.invoke(app, ["bench", "--engine", "bogus", "--json", str(leavenworth.csv_dir())])
+    assert result.exit_code != 0
+
+
+def test_bench_rich_mode_runs():
+    """Non-json invocation exits 0 (rich panel rendered to stderr)."""
+    result = runner.invoke(app, ["bench", str(leavenworth.csv_dir())])
+    assert result.exit_code == 0, result.stderr


### PR DESCRIPTION
## Summary

Adds `gmnspy bench <source>` — a single CLI command that times the four
critical hot paths on a GMNS source and prints per-phase + total
wall-clock seconds. Closes #86.

Phases (each timed via `time.perf_counter`):

- `load` — `Network.from_source`
- `validate` — structural / schema only (`foreign_keys=False, sync_state=False`)
- `links_count` + `nodes_count` — trivial materialisation sanity
- `is_connected` — full igraph build + component count; skipped silently
  if the `[clean]` extra is not installed (entry recorded with
  `seconds: null, skipped: "igraph not installed"`)

Output is a stable dict — `{source, engine, total_seconds, phases:
[{phase, seconds}, ...]}` — renderable as a rich panel or as JSON via
`--json`. The shape is designed so a future pytest-benchmark CI
workflow (Phase 5) can diff timings without re-parsing rich output.

`--engine ibis|pandas|polars` mirrors the resolver pattern used by
sibling 4.x commands. A local `_resolve_engine` helper keeps this PR
independent of #84 landing first.

## Test plan

- [x] `uv run pytest packages/gmnspy/tests/test_cli_bench.py -v` — 4 new tests pass
- [x] `uv run pytest` — 784 passed (was 780; +4)
- [x] `uv run ruff check packages/ scripts/ main.py` — clean
- [x] `uv run ruff format --check packages/ scripts/ main.py` — clean
- [x] `uv run lint-imports` — 2 contracts kept, 0 broken
- [x] `uv run python scripts/lint_no_sql.py` — clean

## Deferred (per task brief)

- pytest-benchmark integration → Phase 5 bench CI workflow
- Persisted history file → out of scope
- Comparison vs baseline → out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)