### PR TITLE
feat(cli): gmnspy spec list/diff + doctor (#85, #87)

### DIFF
--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -9,9 +9,9 @@ on top:
   named-table summary (links, nodes, segments, …) rather than the
   generic resource list.
 * ``quality`` — runs the :mod:`gmnspy.quality` rule pack.
-
-Future Phase 4 tasks add ``read``, ``spec``, ``clean``, ``index`` per
-the architecture (tasks 4.3 / 4.6).
+* ``spec list`` / ``spec diff`` — introspect vendored GMNS spec
+  versions (task 4.3 / issue #85).
+* ``doctor`` — environment + spec smoke checks (task 4.5 / issue #87).
 
 Every command keeps the ``--json`` + ``--yes`` contract from
 :mod:`datagrove.cli` so an agent that learned the datagrove surface
@@ -20,16 +20,20 @@ already knows the GMNS surface.
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os
+import sys
 from pathlib import Path
 
 import typer
 from datagrove.cli.app import build_app
-from datagrove.cli.render import render_dict, render_issues
+from datagrove.cli.render import render_dict, render_issues, render_table
 from datagrove.quality import RuleConfig, run_quality
 
 from gmnspy import Network
 from gmnspy.quality import register_all
+from gmnspy.spec import DEFAULT_SPEC, SUPPORTED_SPECS, load_gmns_spec
 
 __all__ = ["app"]
 
@@ -96,6 +100,62 @@ def _build_gmnspy_app() -> typer.Typer:
         # from this command. Callers wanting hard fail use --json + check
         # for non-empty issues themselves.
 
+    # ------------------------------------------------------------------
+    # spec — vendored GMNS spec introspection (task 4.3 / issue #85)
+    # ------------------------------------------------------------------
+    spec_app = typer.Typer(no_args_is_help=True, help="GMNS spec utilities — list and diff vendored versions.")
+    gmnspy_app.add_typer(spec_app, name="spec")
+
+    @spec_app.command(name="list")
+    def spec_list(
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON instead of a rich table."),
+    ) -> None:
+        """List the GMNS spec versions vendored in this build of gmnspy."""
+        data = {"default": DEFAULT_SPEC, "supported": list(SUPPORTED_SPECS)}
+        render_dict(data, json_out=json_out, title="gmnspy spec list")
+
+    @spec_app.command(name="diff")
+    def spec_diff(
+        v1: str = typer.Argument(..., help="Baseline GMNS spec version (e.g. 0.96)."),
+        v2: str = typer.Argument(..., help="Comparison GMNS spec version (e.g. 0.97)."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON instead of a rich summary."),
+    ) -> None:
+        """Diff two vendored GMNS spec versions resource-by-resource."""
+        diff = _diff_specs(v1, v2)
+        if json_out:
+            render_dict(diff, json_out=True)
+            return
+        # Human-readable summary: one row per "changed" resource plus
+        # bare lists for added/removed. Keep it compact — the JSON
+        # payload is the authoritative shape.
+        summary = {
+            "v1": diff["v1"],
+            "v2": diff["v2"],
+            "added_resources": ", ".join(diff["added_resources"]) or "(none)",
+            "removed_resources": ", ".join(diff["removed_resources"]) or "(none)",
+            "changed_resources": ", ".join(r["name"] for r in diff["changed_resources"]) or "(none)",
+        }
+        render_dict(summary, json_out=False, title=f"spec diff: {v1} -> {v2}")
+
+    # ------------------------------------------------------------------
+    # doctor — environment diagnostic (task 4.5 / issue #87)
+    # ------------------------------------------------------------------
+    @gmnspy_app.command(name="doctor")
+    def doctor(
+        json_out: bool = typer.Option(False, "--json", help="Emit checks as a JSON array."),
+    ) -> None:
+        """Run environment + spec smoke checks. Exits non-zero on any failure."""
+        checks: list[dict[str, object]] = [
+            _check_python_version(),
+            *_check_optional_extras(),
+            *_check_spec_versions(),
+            _check_leavenworth_loads(),
+            _check_auto_approve_env(),
+        ]
+        render_table(checks, json_out=json_out, title="gmnspy doctor")
+        if any(not c["ok"] for c in checks):
+            raise typer.Exit(code=1)
+
     return gmnspy_app
 
 
@@ -108,6 +168,161 @@ def _safe_count(net: Network, table_name: str) -> int | None:
         return table.count()
     except Exception:  # pragma: no cover - best effort for `info`
         return None
+
+
+# ---------------------------------------------------------------------------
+# spec diff helpers (task 4.3 / issue #85)
+# ---------------------------------------------------------------------------
+
+
+def _field_map(resource) -> dict[str, str | None]:  # type: ignore[no-untyped-def]
+    """Return ``{field_name: type}`` for a resource, or ``{}`` if schemaless.
+
+    Uses :attr:`Resource.table_schema` (the Python attribute name —
+    accessing ``.schema`` directly emits a FutureWarning and returns a
+    bound method, not the schema data).
+    """
+    schema = resource.table_schema
+    if schema is None or isinstance(schema, str):
+        return {}
+    return {f.name: f.type for f in schema.fields}
+
+
+def _diff_specs(v1: str, v2: str) -> dict[str, object]:
+    """Compute a structural diff between two vendored GMNS spec versions.
+
+    Returns a dict with ``v1``, ``v2``, ``added_resources``,
+    ``removed_resources``, and ``changed_resources`` keys; see
+    docstring on the CLI command for the exact shape.
+    """
+    pkg_v1 = load_gmns_spec(v1)
+    pkg_v2 = load_gmns_spec(v2)
+    res_v1 = {r.name: r for r in pkg_v1.resources}
+    res_v2 = {r.name: r for r in pkg_v2.resources}
+    names_v1 = set(res_v1)
+    names_v2 = set(res_v2)
+
+    changed: list[dict[str, object]] = []
+    for name in sorted(names_v1 & names_v2):
+        fields_v1 = _field_map(res_v1[name])
+        fields_v2 = _field_map(res_v2[name])
+        added_fields = sorted(set(fields_v2) - set(fields_v1))
+        removed_fields = sorted(set(fields_v1) - set(fields_v2))
+        changed_fields = [
+            {"name": fname, "v1_type": fields_v1[fname], "v2_type": fields_v2[fname]}
+            for fname in sorted(set(fields_v1) & set(fields_v2))
+            if fields_v1[fname] != fields_v2[fname]
+        ]
+        if added_fields or removed_fields or changed_fields:
+            changed.append(
+                {
+                    "name": name,
+                    "added_fields": added_fields,
+                    "removed_fields": removed_fields,
+                    "changed_fields": changed_fields,
+                }
+            )
+
+    return {
+        "v1": v1,
+        "v2": v2,
+        "added_resources": sorted(names_v2 - names_v1),
+        "removed_resources": sorted(names_v1 - names_v2),
+        "changed_resources": changed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# doctor check helpers (task 4.5 / issue #87)
+# ---------------------------------------------------------------------------
+
+
+def _check_python_version() -> dict[str, object]:
+    """Verify Python 3.11+ — matches pyproject ``requires-python``."""
+    ver = sys.version_info
+    ok = ver >= (3, 11)
+    return {
+        "name": "python_version",
+        "ok": ok,
+        "detail": f"{ver.major}.{ver.minor}.{ver.micro} ({'>=3.11' if ok else 'requires >=3.11'})",
+    }
+
+
+# Optional-extra → import probe. Each entry is (extra-name, module-to-import).
+# The extra is informational; the import is what actually decides ok/!ok.
+_EXTRA_PROBES: tuple[tuple[str, str], ...] = (
+    ("clean", "shapely"),
+    ("clean", "igraph"),
+    ("server", "fastapi"),
+    ("mcp", "mcp"),
+    ("notebook", "ipywidgets"),
+)
+
+
+def _check_optional_extras() -> list[dict[str, object]]:
+    """One check per (extra, probe-module). ``ok=False`` is informational, not fatal — see _check_leavenworth_loads."""
+    out: list[dict[str, object]] = []
+    for extra, module in _EXTRA_PROBES:
+        try:
+            importlib.import_module(module)
+            out.append({"name": f"extra:{extra}[{module}]", "ok": True, "detail": "importable"})
+        except ImportError as exc:
+            out.append(
+                {
+                    "name": f"extra:{extra}[{module}]",
+                    "ok": True,  # optional — absence is not a failure
+                    "detail": f"not installed ({exc.__class__.__name__}); install with `uv sync --extra {extra}`",
+                }
+            )
+    return out
+
+
+def _check_spec_versions() -> list[dict[str, object]]:
+    """Each vendored spec version must parse without error."""
+    out: list[dict[str, object]] = []
+    for version in SUPPORTED_SPECS:
+        try:
+            pkg = load_gmns_spec(version)
+            out.append(
+                {
+                    "name": f"spec:{version}",
+                    "ok": True,
+                    "detail": f"{len(pkg.resources)} resources",
+                }
+            )
+        except Exception as exc:  # pragma: no cover - vendored data is checked in
+            out.append({"name": f"spec:{version}", "ok": False, "detail": f"{exc.__class__.__name__}: {exc}"})
+    return out
+
+
+def _check_leavenworth_loads() -> dict[str, object]:
+    """Smoke test: the Leavenworth fixture should load + report a link table."""
+    try:
+        from gmnspy.fixtures import leavenworth
+
+        net = Network.from_source(leavenworth.csv_dir())
+        link_count = _safe_count(net, "link")
+        return {
+            "name": "fixture:leavenworth",
+            "ok": link_count is not None and link_count > 0,
+            "detail": f"loaded {link_count} links from csv fixture",
+        }
+    except Exception as exc:
+        return {
+            "name": "fixture:leavenworth",
+            "ok": False,
+            "detail": f"{exc.__class__.__name__}: {exc}",
+        }
+
+
+def _check_auto_approve_env() -> dict[str, object]:
+    """Informational: report whether DATAGROVE_AUTO_APPROVE is set."""
+    value = os.environ.get("DATAGROVE_AUTO_APPROVE")
+    return {
+        "name": "env:DATAGROVE_AUTO_APPROVE",
+        "ok": True,  # informational only
+        "detail": f"set to {value!r}" if value is not None else "unset (interactive consent required)",
+    }
 
 
 # Module-level app for the `gmnspy` console-script entry point.

--- a/packages/gmnspy/tests/test_cli_spec_doctor.py
+++ b/packages/gmnspy/tests/test_cli_spec_doctor.py
@@ -1,0 +1,91 @@
+"""Tests for ``gmnspy spec list/diff`` + ``gmnspy doctor`` (tasks 4.3 / 4.5).
+
+Issues: #85 (spec list/diff), #87 (doctor).
+
+Follows the pattern in ``test_cli.py`` — uses :class:`typer.testing.CliRunner`
+and asserts on ``--json`` payloads (the rich path is exercised
+incidentally by running the commands at all).
+"""
+
+from __future__ import annotations
+
+import json
+
+from gmnspy.cli.app import app
+from gmnspy.spec import DEFAULT_SPEC, SUPPORTED_SPECS
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# spec list
+# ---------------------------------------------------------------------------
+
+
+def test_spec_list_json_lists_supported_versions():
+    """`gmnspy spec list --json` returns {default, supported} matching the module constants."""
+    result = runner.invoke(app, ["spec", "list", "--json"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["default"] == DEFAULT_SPEC
+    assert payload["supported"] == list(SUPPORTED_SPECS)
+
+
+# ---------------------------------------------------------------------------
+# spec diff
+# ---------------------------------------------------------------------------
+
+
+def test_spec_diff_returns_resource_deltas():
+    """Diffing two adjacent versions returns the documented shape (structure-only test)."""
+    result = runner.invoke(app, ["spec", "diff", "--json", "0.96", "0.97"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["v1"] == "0.96"
+    assert payload["v2"] == "0.97"
+    assert isinstance(payload["added_resources"], list)
+    assert isinstance(payload["removed_resources"], list)
+    assert isinstance(payload["changed_resources"], list)
+    # If any resource changed, each entry has the documented keys.
+    for entry in payload["changed_resources"]:
+        assert set(entry) >= {"name", "added_fields", "removed_fields", "changed_fields"}
+        for change in entry["changed_fields"]:
+            assert set(change) >= {"name", "v1_type", "v2_type"}
+
+
+def test_spec_diff_same_version_returns_empty_diffs():
+    """Diffing a version against itself yields empty added/removed/changed lists."""
+    result = runner.invoke(app, ["spec", "diff", "--json", "0.97", "0.97"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["added_resources"] == []
+    assert payload["removed_resources"] == []
+    assert payload["changed_resources"] == []
+
+
+# ---------------------------------------------------------------------------
+# doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_runs_and_returns_checks():
+    """`gmnspy doctor` exits 0 in a healthy env and prints a meaningful number of checks."""
+    result = runner.invoke(app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    # python-version + 3 spec versions + leavenworth + env + at least one extra
+    assert len(payload) >= 3
+
+
+def test_doctor_json_mode():
+    """The JSON payload is a list of dicts with name/ok/detail keys."""
+    result = runner.invoke(app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    for check in payload:
+        assert set(check) >= {"name", "ok", "detail"}
+        assert isinstance(check["name"], str)
+        assert isinstance(check["ok"], bool)
+        assert isinstance(check["detail"], str)


### PR DESCRIPTION
## Summary
- `gmnspy spec list` + `gmnspy spec diff v1 v2` — introspect vendored GMNS spec versions (closes #85, partial — `spec sync` deferred).
- `gmnspy doctor` — environment diagnostic covering Python version, optional extras, all `SUPPORTED_SPECS` parsing, Leavenworth fixture smoke load, and `DATAGROVE_AUTO_APPROVE` state. Exits non-zero on required-check failure (closes #87).
- Helpers (`_diff_specs`, `_check_*`) live at module level for direct unit testing.

## Test plan
- [x] `uv run pytest packages/gmnspy/tests/test_cli_spec_doctor.py -v` — 5/5 pass
- [x] `uv run pytest` — 785 pass (was 780; +5 new), 48 skipped
- [x] `uv run ruff check packages/ scripts/ main.py` — clean
- [x] `uv run ruff format --check packages/ scripts/ main.py` — clean
- [x] `uv run lint-imports` — 2/2 contracts kept
- [x] `uv run python scripts/lint_no_sql.py` — clean

## Deferred
- `gmnspy spec sync` (the workflow-bot piece of #85) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)