### PR TITLE
feat(skills): five Claude Code Skills (#95)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -2,20 +2,39 @@
 
 Claude Code Skills shipped with the GMNSpy + datagrove monorepo.
 
+## What's a Skill?
+
+A Skill is a single markdown file (`SKILL.md`) with YAML frontmatter that
+teaches Claude Code *when* and *how* to use a specific tool or workflow.
+Each skill below covers one focused capability — validation, authoring,
+conversion, or cleaning — with concrete examples that work against the
+installed packages.
+
+Skills are read by both humans and AI. Reading them top-to-bottom is the
+fastest way to learn the corresponding feature.
+
 ## Install
 
-Skills are loaded from this repository — no hosting required. From your terminal:
+Skills are loaded directly from this repository — no separate hosting.
+Install one at a time:
 
 ```bash
 claude code skill add https://github.com/e-lo/GMNSpy.git#path=skills/gmns-validate
 ```
 
-Replace `gmns-validate` with any subdirectory below.
+Replace `gmns-validate` with any subdirectory listed below.
 
 ## Available skills
 
-- [`datagrove-validate`](datagrove-validate/SKILL.md) — generic Frictionless data-package validation guidance.
-- [`gmns-author`](gmns-author/SKILL.md) — authoring and editing GMNS networks.
-- [`gmns-validate`](gmns-validate/SKILL.md) — interpreting GMNS validation reports + data-quality flags.
-- [`gmns-convert`](gmns-convert/SKILL.md) — converting between GMNS storage formats.
-- [`gmns-clean`](gmns-clean/SKILL.md) — safely cleaning networks with rollback.
+| Skill                                              | Use when…                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------- |
+| [`datagrove-validate`](datagrove-validate/SKILL.md) | Validating any Frictionless data package — generic, not GMNS-specific.    |
+| [`gmns-author`](gmns-author/SKILL.md)               | Authoring or editing a GMNS network from scratch.                         |
+| [`gmns-validate`](gmns-validate/SKILL.md)           | Interpreting `gmnspy validate` and `gmnspy quality` reports.              |
+| [`gmns-convert`](gmns-convert/SKILL.md)             | Converting GMNS data between CSV, Parquet, DuckDB, and zip-CSV formats.   |
+| [`gmns-clean`](gmns-clean/SKILL.md)                 | Simplifying geometries, merging nodes, dropping orphans — with rollback.  |
+
+## License
+
+All skills are licensed under Apache-2.0, the same as the rest of this
+repository. See [LICENSE](../LICENSE) for the full text.

--- a/skills/datagrove-validate/SKILL.md
+++ b/skills/datagrove-validate/SKILL.md
@@ -1,10 +1,119 @@
 ---
 name: datagrove-validate
-description: Validate a Frictionless data package
+description: Validate any Frictionless-aligned tabular data package using the datagrove CLI. Use when the user has a directory with datapackage.json + table files (CSV/Parquet) and wants schema, type, and foreign-key validation — independent of GMNS.
 ---
 
 # datagrove-validate
 
-Guidance for validating any Frictionless-aligned tabular data package using datagrove.
+Use this skill when a user points at a folder, zip, or DuckDB file containing a
+Frictionless `datapackage.json` and asks "is this valid?", "what's wrong with
+this data?", or wants to gate a pipeline on schema conformance.
 
-*Skill body is a placeholder; populated in Phase 4 task 4.12.*
+`datagrove` is the generic Frictionless validation engine that underpins
+`gmnspy`. It knows nothing about GMNS — it validates whatever schema your
+`datapackage.json` declares. If the user's question is specifically about GMNS
+semantics (lane counts, network connectivity, etc.), use the `gmns-validate`
+skill instead.
+
+## Workflow
+
+1. **Locate the source.** A datagrove source is one of:
+   - A directory with `datapackage.json` at its root
+   - A `.zip` containing the same
+   - A `.duckdb` file with a `datapackage` table
+   - A single CSV/Parquet with an inferred schema (`--infer`)
+2. **Run `datagrove info` first** to confirm datagrove can read the package
+   and see which tables it found. This catches missing files, bad JSON, or
+   wrong working directory before the slower validation pass.
+3. **Run `datagrove validate <source> --json`** and capture stdout. The JSON
+   shape is:
+   ```json
+   {
+     "source": "...",
+     "ok": false,
+     "summary": {"errors": 3, "warnings": 12, "tables": 5},
+     "issues": [
+       {"table": "link", "code": "schema.required",
+        "severity": "error", "row": 14, "field": "from_node_id",
+        "message": "..."}
+     ]
+   }
+   ```
+4. **Group issues by severity.** Always surface `error` first, then
+   `warning`, then `info`. Within severity, group by `code` so the user sees
+   "23 of these, all the same root cause" rather than a 200-line wall.
+5. **Map common codes to remedies:**
+   - `schema.required` → required column missing or null; check the source
+     export
+   - `schema.type` → cell can't parse as declared type; usually empty strings
+     vs nulls, or commas in numeric fields
+   - `schema.enum` → value outside the allowed list; check schema vs source
+     vocabulary
+   - `fk.missing_target` → foreign key points at an id that doesn't exist in
+     the parent table; usually a join key drift or stale export
+   - `package.missing_resource` → `datapackage.json` references a file that
+     isn't on disk
+6. **Suggest the next command.** If the user has issues to triage, point them
+   at `datagrove validate <source> --severity=error --json` to filter, or at
+   `--table=<name>` to scope to one resource.
+
+## Example
+
+Validate a package, count issues by code, print top offenders:
+
+```bash
+# Quick sanity check
+datagrove info ./my_package
+
+# Full validation, JSON output piped to jq
+datagrove validate ./my_package --json \
+  | jq '.issues | group_by(.code) | map({code: .[0].code, count: length})'
+```
+
+Example output:
+
+```json
+[
+  {"code": "fk.missing_target", "count": 47},
+  {"code": "schema.required", "count": 3},
+  {"code": "schema.type", "count": 1}
+]
+```
+
+Interpretation:
+
+- 47 `fk.missing_target` from one table almost always means a join column was
+  renamed or an upstream filter dropped rows. Don't fix 47 rows by hand —
+  re-run the export.
+- 3 `schema.required` is fixable inline; tell the user which rows.
+- 1 `schema.type` is usually a single dirty cell; show the row and field.
+
+For Python integration:
+
+```python
+from datagrove import Package
+
+pkg = Package.from_source("./my_package")
+report = pkg.validate()  # ValidationReport
+print(report.ok, report.summary)
+for issue in report.errors():
+    print(issue.code, issue.table, issue.row, issue.message)
+```
+
+## Severity guidance
+
+- `error` — schema violation; downstream consumers will break. Block the
+  pipeline.
+- `warning` — likely-bad data that still parses; surface to the user but
+  don't block.
+- `info` — advisory; e.g. "table has 0 rows".
+
+When reporting to the user, never say "the data is valid" if there are
+warnings. Say "0 errors, N warnings — here's what to look at."
+
+## See also
+
+- `gmns-validate` — GMNS-specific schema and quality codes
+- `gmns-convert` — convert between datagrove-readable formats
+- Frictionless Data spec: <https://specs.frictionlessdata.io/>
+- Repo docs: `packages/datagrove/README.md`

--- a/skills/gmns-author/SKILL.md
+++ b/skills/gmns-author/SKILL.md
@@ -1,10 +1,148 @@
 ---
 name: gmns-author
-description: Author and edit GMNS networks
+description: Author or edit a GMNS network from scratch — the minimum link.csv + node.csv schema, common pitfalls, and a validate-as-you-go loop. Use when the user wants to construct a small GMNS network programmatically or hand-edit one.
 ---
 
 # gmns-author
 
-Step-by-step guidance for creating or modifying a GMNS network.
+Use this skill when a user says "I want to build a GMNS network for X,"
+"how do I make a node table?", "what columns do I need in link.csv?", or
+asks for a minimal working example. This skill is about *creating* GMNS
+data; for *checking* an existing network, use `gmns-validate`.
 
-*Skill body is a placeholder; populated in Phase 4 task 4.12.*
+A valid GMNS network needs, at minimum, two CSVs (`node.csv` and `link.csv`)
+plus a `datapackage.json` that declares them. The full GMNS spec defines
+many more tables (lane, signal, segment, etc.) but they are all optional.
+Start small, validate, then add tables as needed.
+
+## Workflow
+
+1. **Decide what you're modeling.** Nodes are intersections / endpoints;
+   links are the roadway segments between them. Every link references two
+   nodes by id.
+2. **Write `node.csv` first.** Required columns:
+   - `node_id` (int, unique, primary key)
+   - `x_coord` (float, longitude in WGS84 unless your schema says otherwise)
+   - `y_coord` (float, latitude)
+   Optional but common: `node_type`, `ctrl_type`, `zone_id`.
+3. **Write `link.csv`.** Required columns:
+   - `link_id` (int, unique)
+   - `from_node_id` (int, FK → node.node_id)
+   - `to_node_id` (int, FK → node.node_id)
+   - `length` (float, meters by default)
+   - `lanes` (int)
+   - `free_speed` (float, in your declared units — kph or mph)
+   - `capacity` (float, vehicles per hour per lane)
+   Optional: `facility_type`, `link_type`, `geometry` (WKT LINESTRING),
+   `dir_flag`.
+4. **Create `datapackage.json`.** The easiest path is to copy the GMNS
+   reference one from `packages/gmnspy/gmnspy/fixtures/leavenworth/csv/` and
+   trim it to just `node` and `link`.
+5. **Validate after every change.** Run `gmnspy validate <dir> --json`
+   between edits. Fix `schema.required` and `fk.missing_target` before
+   adding more rows.
+6. **Load it programmatically** with `Network.from_source(path)` to confirm
+   it round-trips through the gmnspy data model.
+
+## Example
+
+A 3-node, 2-link network — the smallest useful GMNS example. Save these
+three files in a fresh directory:
+
+`node.csv`
+
+```csv
+node_id,x_coord,y_coord,node_type
+1,-120.6615,47.5965,
+2,-120.6602,47.5961,
+3,-120.6588,47.5957,
+```
+
+`link.csv`
+
+```csv
+link_id,from_node_id,to_node_id,length,lanes,free_speed,capacity,facility_type
+101,1,2,105.4,2,40,1800,local
+102,2,3,108.7,2,40,1800,local
+```
+
+`datapackage.json`
+
+```json
+{
+  "name": "tiny-gmns",
+  "profile": "tabular-data-package",
+  "resources": [
+    {
+      "name": "node",
+      "path": "node.csv",
+      "schema": {
+        "fields": [
+          {"name": "node_id", "type": "integer", "constraints": {"required": true, "unique": true}},
+          {"name": "x_coord", "type": "number", "constraints": {"required": true}},
+          {"name": "y_coord", "type": "number", "constraints": {"required": true}},
+          {"name": "node_type", "type": "string"}
+        ],
+        "primaryKey": "node_id"
+      }
+    },
+    {
+      "name": "link",
+      "path": "link.csv",
+      "schema": {
+        "fields": [
+          {"name": "link_id", "type": "integer", "constraints": {"required": true, "unique": true}},
+          {"name": "from_node_id", "type": "integer", "constraints": {"required": true}},
+          {"name": "to_node_id", "type": "integer", "constraints": {"required": true}},
+          {"name": "length", "type": "number"},
+          {"name": "lanes", "type": "integer"},
+          {"name": "free_speed", "type": "number"},
+          {"name": "capacity", "type": "number"},
+          {"name": "facility_type", "type": "string"}
+        ],
+        "primaryKey": "link_id",
+        "foreignKeys": [
+          {"fields": "from_node_id", "reference": {"resource": "node", "fields": "node_id"}},
+          {"fields": "to_node_id",   "reference": {"resource": "node", "fields": "node_id"}}
+        ]
+      }
+    }
+  ]
+}
+```
+
+Validate and load:
+
+```bash
+gmnspy validate ./tiny-gmns --json | jq '.summary'
+# {"errors": 0, "warnings": 0, "tables": 2}
+```
+
+```python
+from gmnspy import Network
+
+net = Network.from_source("./tiny-gmns")
+print(len(net.nodes), "nodes;", len(net.links), "links")
+# 3 nodes; 2 links
+```
+
+## Common pitfalls
+
+- **Off-by-one node ids** in `from_node_id` / `to_node_id` → `fk.missing_target`.
+  Always validate after appending links.
+- **Lat/lon swapped** (`x_coord` is *longitude*, `y_coord` is *latitude*).
+  If your nodes plot in the wrong hemisphere, you swapped them.
+- **Mixed units.** Pick meters or feet for `length` and stick with it; declare
+  in `datapackage.json` if your schema supports it.
+- **Stranded nodes** are warnings, not errors — but they often mean you
+  forgot a link.
+- **Duplicate link_id when extending** — append, don't overwrite, and keep a
+  max id counter.
+
+## See also
+
+- `gmns-validate` — interpreting the report after you save changes
+- `gmns-convert` — once authored, convert to parquet for sharing
+- `docs/gmns-data-model.md` — full table inventory and field reference
+- GMNS spec: <https://github.com/zephyr-data-specs/GMNS>
+- Reference fixture: `packages/gmnspy/gmnspy/fixtures/leavenworth/csv/`

--- a/skills/gmns-clean/SKILL.md
+++ b/skills/gmns-clean/SKILL.md
@@ -1,10 +1,136 @@
 ---
 name: gmns-clean
-description: Clean and edit GMNS networks safely
+description: Apply network-editing operations (simplify geometries, merge close nodes, drop orphans) to a GMNS network inside a transactional Session that supports commit or rollback. Use when the user wants to tidy a network without risking destructive changes.
 ---
 
 # gmns-clean
 
-Use gmnspy.clean ops (simplify geometry, merge close nodes, etc.) with rollback semantics.
+Use this skill when a user wants to clean up a GMNS network — drop stranded
+nodes, merge nodes that are within a few meters of each other, simplify
+overdetailed link geometries, or remove duplicate links — and wants to
+preview the result before committing. The `gmnspy.clean` operations all run
+inside a `datagrove.editing.Session`, which records every mutation so you
+can either `commit()` or `rollback()` at the end.
 
-*Skill body is a placeholder; populated in Phase 4 task 4.12.*
+This skill requires the `[clean]` extra, which pulls in `shapely` (for
+geometry ops) and `igraph` (for connectivity analysis):
+
+```bash
+pip install "gmnspy[clean]"
+# or, in this repo:
+uv sync --extra clean
+```
+
+For *finding* what needs cleaning, use `gmns-validate` first — the quality
+warnings tell you which operations to run.
+
+## Workflow
+
+1. **Validate first** so you know what's actually wrong:
+   ```bash
+   gmnspy validate ./net --json | jq '.issues | group_by(.code)
+       | map({code: .[0].code, count: length})'
+   ```
+2. **Open a `Session` around the network.** The `with` block is the
+   transaction boundary; exiting without `commit()` rolls everything back.
+3. **Run clean ops in this order** (matters — geometry before topology):
+   1. `simplify_geometry` — drop redundant vertices on link geometries
+   2. `merge_close_nodes` — collapse near-duplicate nodes (re-routes their
+      links to the survivor)
+   3. `drop_stranded_nodes` — remove nodes with no incident links
+   4. `dedupe_links` — collapse parallel duplicates (with a strategy:
+      `keep_first`, `keep_highest_capacity`, etc.)
+4. **Inspect the diff** (`session.summary()`) before committing. The
+   summary tells you how many rows were added / modified / removed per
+   table.
+5. **Commit or roll back:**
+   - `session.commit()` writes the changes to the live `Network` object
+   - exiting the `with` block *without* committing rolls them back
+6. **Re-validate** after committing to confirm the issue counts dropped
+   and no new errors appeared.
+
+## Example
+
+End-to-end clean of a network with stranded nodes and over-detailed
+geometries:
+
+```python
+from gmnspy import Network
+from gmnspy.clean import (
+    simplify_geometry,
+    merge_close_nodes,
+    drop_stranded_nodes,
+    dedupe_links,
+)
+from datagrove.editing import Session
+
+net = Network.from_source("./network")
+
+with Session(net) as s:
+    simplify_geometry(net, s, tolerance_m=1.0)
+    merge_close_nodes(net, s, threshold_m=5.0)
+    drop_stranded_nodes(net, s)
+    dedupe_links(net, s, strategy="keep_highest_capacity")
+
+    print(s.summary())
+    # {"node": {"removed": 12, "modified": 3},
+    #  "link": {"removed": 4, "modified": 87}}
+
+    # Preview only — if this looks wrong, just don't commit.
+    s.commit()
+
+# Persist to disk
+net.write("./network_clean", format="csv")
+```
+
+Rollback example (no commit, no changes survive):
+
+```python
+with Session(net) as s:
+    drop_stranded_nodes(net, s)
+    if s.summary()["node"]["removed"] > 100:
+        # Too aggressive — bail out
+        raise RuntimeError("unexpected node count; aborting")
+    s.commit()
+```
+
+If the `RuntimeError` fires, the `Session` exits without committing and
+`net` is untouched.
+
+## Per-op notes
+
+- **`simplify_geometry(net, s, tolerance_m=1.0)`** — Douglas-Peucker on
+  `link.geometry` (WKT LINESTRING). Tolerance is in meters; 1 m is safe for
+  most road networks, 5 m for regional studies. Leaves endpoints untouched.
+- **`merge_close_nodes(net, s, threshold_m=5.0)`** — finds node clusters
+  within `threshold_m`, picks one survivor per cluster (lowest `node_id`),
+  rewrites `from_node_id` / `to_node_id` on all affected links, then drops
+  the merged nodes. Will not merge nodes connected by a link (those are
+  legitimate short segments).
+- **`drop_stranded_nodes(net, s)`** — removes nodes with no incident links.
+  Always safe; reversible inside the session.
+- **`dedupe_links(net, s, strategy=...)`** — collapses links sharing the
+  same `(from_node_id, to_node_id)` pair. Strategies:
+  - `"keep_first"` — keep lowest `link_id`
+  - `"keep_highest_capacity"` — keep the link with the largest `capacity`
+  - `"keep_widest"` — keep the link with the most `lanes`
+
+## Pitfalls
+
+- **`merge_close_nodes` is sensitive to threshold.** 5 m collapses true
+  duplicates; 20 m starts eating real intersections. When in doubt, run on
+  a copy first.
+- **Order matters.** Don't `drop_stranded_nodes` *before* `merge_close_nodes`
+  — the merge can produce strandeds the drop would have missed.
+- **Geometry simplification preserves topology**, but if your geometries
+  are wildly malformed (self-intersecting), `simplify_geometry` won't fix
+  that. Repair geometries upstream first.
+- **The Session holds the whole diff in memory.** For >5M-link networks,
+  chunk the operations or skip the session and edit tables directly.
+
+## See also
+
+- `gmns-validate` — find what needs cleaning before you start
+- `gmns-author` — manual edits as an alternative to ops
+- `packages/gmnspy/tests/test_clean.py` — runnable examples for every op
+- `packages/datagrove/datagrove/editing/session.py` — Session internals

--- a/skills/gmns-convert/SKILL.md
+++ b/skills/gmns-convert/SKILL.md
@@ -1,10 +1,125 @@
 ---
 name: gmns-convert
-description: Convert between GMNS formats
+description: Convert GMNS (or any datagrove) data between csv, parquet, duckdb, and zip-csv formats. Use when the user has data in one storage format and needs another — e.g. CSVs to parquet for a faster pipeline, or duckdb to CSV for sharing.
 ---
 
 # gmns-convert
 
-Convert GMNS networks between csv, parquet, duckdb, and zipped-csv.
+Use this skill when the user has GMNS (or generic Frictionless) data in one
+format and wants it in another: CSV folders, Parquet files, DuckDB
+databases, or zipped CSV bundles. The validation and authoring skills
+should not be your first stop for this — `gmns-convert` is purely about
+round-tripping a `Package` between storage backends.
 
-*Skill body is a placeholder; populated in Phase 4 task 4.12.*
+All format conversion preserves the `datapackage.json` schema, so a
+round-trip is lossless for typed columns. (Notable exception: WKT geometry
+columns survive any format; native geo types are not normalized.)
+
+## Workflow
+
+1. **Confirm the source is valid first.** A bad source produces a bad
+   destination. Run `datagrove info <src>` (or `gmnspy info <src>` for
+   GMNS) to be sure the schema reads cleanly.
+2. **Pick the destination format:**
+   - **CSV folder** — human-readable, diff-friendly, slow on big tables
+   - **Parquet folder** — fastest reads, typed, smaller on disk; preferred
+     for pipelines
+   - **DuckDB** — single-file database, great for ad-hoc SQL queries
+   - **Zip CSV** — single-file portable bundle; nice for email/uploads
+3. **Run the convert command.** Once PR #84 lands, the canonical command
+   is:
+   ```bash
+   datagrove convert <src> <dest> --format=parquet
+   ```
+   Until then, do it programmatically with the Package API (see example).
+4. **Validate the destination.** `datagrove validate <dest>` after every
+   conversion. A schema-preserving round-trip should produce 0 new issues.
+
+## Format choice cheat-sheet
+
+| Use case                              | Pick     |
+| ------------------------------------- | -------- |
+| Sharing with a non-Python collaborator | CSV zip  |
+| Loading into a pipeline               | Parquet  |
+| Interactive SQL exploration           | DuckDB   |
+| Version-controlled in git             | CSV      |
+| Largest networks (>10M links)         | Parquet  |
+
+## Example: Leavenworth CSV → Parquet round-trip
+
+Using the bundled Leavenworth fixture:
+
+```bash
+# Once PR #84 is merged:
+datagrove convert \
+    packages/gmnspy/gmnspy/fixtures/leavenworth/csv \
+    ./leavenworth_parquet \
+    --format=parquet
+
+datagrove validate ./leavenworth_parquet --json | jq '.summary'
+# {"errors": 0, "warnings": 0, "tables": 9}
+```
+
+Programmatic equivalent (works today):
+
+```python
+from datagrove import Package
+
+src = Package.from_source(
+    "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"
+)
+src.write("./leavenworth_parquet", format="parquet")
+
+# Round-trip check
+dst = Package.from_source("./leavenworth_parquet")
+assert dst.validate().ok
+```
+
+## Example: CSV → DuckDB for ad-hoc SQL
+
+```python
+from datagrove import Package
+
+pkg = Package.from_source("./my_network")
+pkg.write("./my_network.duckdb", format="duckdb")
+```
+
+```bash
+duckdb ./my_network.duckdb \
+  "SELECT facility_type, COUNT(*) AS n
+     FROM link
+    GROUP BY 1
+    ORDER BY n DESC;"
+```
+
+## Example: zip a package for sharing
+
+```python
+from datagrove import Package
+
+Package.from_source("./my_network").write(
+    "./my_network.zip", format="zip-csv"
+)
+```
+
+The recipient runs `datagrove validate my_network.zip` directly against
+the zip — no unpack step needed.
+
+## Pitfalls
+
+- **Don't overwrite the source.** Always write to a fresh directory; the
+  writer assumes the destination is empty.
+- **Parquet column types are stricter than CSV.** A CSV column that happens
+  to be all integers but is declared `string` will write a string column.
+  If you want typed numeric output, fix the schema first.
+- **DuckDB writes one file** — losing the file loses everything. CSV/Parquet
+  directories degrade more gracefully under partial corruption.
+- **Geometry as WKT survives all formats.** Native geo types (e.g.
+  GeoParquet) are not currently emitted.
+
+## See also
+
+- `datagrove-validate` — validate before and after conversion
+- `gmns-validate` — GMNS-specific checks on the converted output
+- PR #84 — adds the first-class `datagrove convert` CLI command
+- `packages/datagrove/datagrove/io/` — read/write backends per format

--- a/skills/gmns-validate/SKILL.md
+++ b/skills/gmns-validate/SKILL.md
@@ -1,10 +1,144 @@
 ---
 name: gmns-validate
-description: Interpret GMNS validation reports
+description: Interpret gmnspy validation reports and data-quality findings on a GMNS network. Use when the user has run gmnspy validate / quality and needs help making sense of the issues, mapping codes to fixes, and prioritizing what to address.
 ---
 
 # gmns-validate
 
-Explain GMNS validation results — spec violations, foreign-key issues, sync-state warnings, and data-quality flags.
+Use this skill when a user shows you output from `gmnspy validate` or
+`gmnspy quality`, asks "what does this error mean?", or has a network
+producing dozens of issues and wants to know which to fix first. This skill
+covers both schema-level validation (does the data parse?) and
+GMNS-specific quality heuristics (does the network make physical sense?).
 
-*Skill body is a placeholder; populated in Phase 4 task 4.12.*
+For *generic* Frictionless validation on non-GMNS data, use the
+`datagrove-validate` skill. For authoring fresh networks, use `gmns-author`.
+
+## Workflow
+
+1. **Always run with `--json`.** The text output is for humans skimming;
+   `--json` gives you a structured array you can group, filter, and count:
+   ```bash
+   gmnspy validate ./network --json > report.json
+   ```
+2. **Read `summary` first.** The header tells you total error/warning counts
+   and which tables had issues. If `errors > 0`, the network won't load
+   cleanly — fix those before quality issues.
+3. **Group by `code`, not by row.** One root cause often emits 100+ issues.
+   ```bash
+   jq '.issues | group_by(.code)
+       | map({code: .[0].code, severity: .[0].severity, count: length})
+       | sort_by(-.count)' report.json
+   ```
+4. **Triage by severity:**
+   - `error` — schema, type, or referential integrity. Fix immediately.
+   - `warning` — quality heuristic flagged something physically suspect.
+     Surface to the user; let them decide.
+   - `info` — advisory only.
+5. **Map the code to a fix.** See the code reference below.
+6. **Re-validate after each batch of fixes.** Don't trust that fixing one
+   `fk.missing_target` doesn't break a different table's FK.
+
+## Issue code reference
+
+### Schema codes (from datagrove)
+
+- **`schema.required`** — required field is null/missing. Open the row and
+  check the source export.
+- **`schema.type`** — value can't be parsed as the declared type. Usually
+  empty strings where numbers are expected, or commas inside numeric cells.
+- **`schema.enum`** — value not in allowed list (e.g. `facility_type =
+  "freewy"`). Check spelling and schema vocabulary.
+- **`fk.missing_target`** — foreign key references an id that doesn't
+  exist. For GMNS, the most common case is `link.from_node_id` or
+  `to_node_id` not in `node.node_id`. Usually means the node table was
+  filtered without filtering links.
+
+### GMNS quality codes (from gmnspy.quality)
+
+- **`quality.disconnected_components`** — the network graph has more than
+  one connected component. Either some links are missing, or the data
+  legitimately covers two unrelated areas. Inspect via
+  `Network.from_source(...).components()`.
+- **`quality.lane_count_mismatch`** — `link.lanes` doesn't match the count
+  of rows in `lane.csv` for that link. Either the lane table is incomplete
+  or `link.lanes` is wrong.
+- **`quality.high_speed_residential`** — `facility_type = "residential"`
+  but `free_speed` > 35 mph (or > 56 kph). Almost always a misclassified
+  facility type. Look at the link's surroundings — it's usually an arterial
+  mistagged.
+- **`quality.zero_length_link`** — `length <= 0`. Either a self-loop
+  (`from_node_id == to_node_id`) or a coordinate bug.
+- **`quality.duplicate_link`** — two links share the same
+  `(from_node_id, to_node_id)` pair. Could be legitimate (parallel
+  facilities) or a data-prep artifact.
+- **`quality.stranded_node`** — a node has no incident links. Usually
+  harmless leftover from a clip operation; safe to drop.
+
+## Example: walking through a `quality.high_speed_residential` issue
+
+The user's report includes:
+
+```json
+{
+  "table": "link",
+  "code": "quality.high_speed_residential",
+  "severity": "warning",
+  "row": 4127,
+  "field": "free_speed",
+  "message": "free_speed=55.0 on facility_type='residential'"
+}
+```
+
+Your response should:
+
+1. Pull the row to confirm:
+   ```python
+   from gmnspy import Network
+   net = Network.from_source("./network")
+   link = net.links.filter(link_id=...).to_pandas().iloc[0]
+   print(link[["link_id", "from_node_id", "to_node_id",
+               "facility_type", "free_speed", "lanes"]])
+   ```
+2. Inspect the surrounding network. A 55 mph "residential" link with 4
+   lanes is almost certainly a minor arterial. Suggest:
+   - Re-classify as `facility_type = "minor_arterial"` (preferred), or
+   - Lower `free_speed` if classification is correct.
+3. Check whether the issue is systemic — if 200 links are flagged, the
+   upstream export is mislabeling a whole road class:
+   ```bash
+   jq '[.issues[] | select(.code == "quality.high_speed_residential")] | length' report.json
+   ```
+4. Don't auto-fix. Quality warnings encode judgment; surface options and let
+   the user pick.
+
+## Example: triaging a fresh report
+
+```bash
+gmnspy validate ./leavenworth --json > report.json
+
+# Headline
+jq '.summary' report.json
+# {"errors": 0, "warnings": 12, "tables": 9}
+
+# Group warnings by code
+jq '.issues | group_by(.code)
+    | map({code: .[0].code, count: length})
+    | sort_by(-.count)' report.json
+# [
+#   {"code": "quality.stranded_node", "count": 7},
+#   {"code": "quality.high_speed_residential", "count": 3},
+#   {"code": "quality.duplicate_link", "count": 2}
+# ]
+```
+
+Prioritize: 7 stranded nodes are likely safe to drop with `gmns-clean`;
+3 high-speed residentials need human review; 2 duplicate links need
+confirmation that they're not parallel facilities.
+
+## See also
+
+- `gmns-author` — fix issues by editing the source tables
+- `gmns-clean` — drop stranded nodes / merge duplicates safely with rollback
+- `datagrove-validate` — non-GMNS Frictionless validation
+- `packages/gmnspy/gmnspy/quality/` — source of every `quality.*` code


### PR DESCRIPTION
## Summary

Populates the five skill bodies scaffolded in Phase 0 (#95). Each `SKILL.md` is a focused, example-driven guide for one capability so Claude Code can invoke the right tool/workflow without rediscovering the package.

- `datagrove-validate` — generic Frictionless validation: `datagrove validate --json`, severity triage, `schema.*` / `fk.*` code reference.
- `gmns-author` — minimum `node.csv` + `link.csv` schema; full 3-node / 2-link worked example with `datapackage.json`; validate-as-you-go loop.
- `gmns-validate` — interpret `gmnspy validate` reports; jq-based code grouping; reference for `schema.*` and `quality.*` codes including `disconnected_components`, `lane_count_mismatch`, `high_speed_residential`.
- `gmns-convert` — round-trip a `Package` between csv / parquet / duckdb / zip-csv via `Package.from_source(...).write(...)` today, `datagrove convert` after PR #84.
- `gmns-clean` — `gmnspy.clean` ops inside a `datagrove.editing.Session` with commit/rollback; calls out the `[clean]` extra.

`skills/README.md` lists install instructions (`claude code skill add …#path=skills/<name>`) and a one-line description per skill. Apache-2.0 throughout.

## Test plan

- [x] `ls skills/*/SKILL.md skills/README.md` — all six files present.
- [x] `head -4` on each `SKILL.md` shows YAML frontmatter with `name` + `description`.
- [x] `uv run ruff check packages/ scripts/ main.py` — passes (no Python touched).
- [ ] Manual: `claude code skill add` against any skill in this branch loads cleanly.

Closes part of #95.

Generated with [Claude Code](https://claude.com/claude-code)