### PR TITLE
feat(mcp): datagrove.mcp + gmnspy.mcp servers (#94)

### DIFF
--- a/packages/datagrove/datagrove/mcp/__init__.py
+++ b/packages/datagrove/datagrove/mcp/__init__.py
@@ -1,1 +1,16 @@
-"""MCP server primitives for exposing data packages to AI agents."""
+"""MCP server primitives for exposing data packages to AI agents (task 4.11).
+
+Stateless tool surface — each tool takes a ``source`` path/URL and
+loads the package fresh per call. See :func:`build_server` for the
+generic tools (``describe_package``, ``validate_package``,
+``list_tables``). Domain packages (e.g. :mod:`gmnspy.mcp`) layer
+network-aware tools on top by passing the same :class:`FastMCP`
+instance through their own ``build_server``.
+
+This module imports ``mcp`` lazily so ``import datagrove`` doesn't
+fail without the optional dependency installed.
+"""
+
+from .server import build_server
+
+__all__ = ["build_server"]

--- a/packages/datagrove/datagrove/mcp/server.py
+++ b/packages/datagrove/datagrove/mcp/server.py
@@ -1,0 +1,148 @@
+"""Generic datagrove MCP server (task 4.11).
+
+Exposes stateless tools over the Model Context Protocol so an AI
+agent (Claude Desktop, Claude Code, ...) can describe + validate any
+Frictionless data package by path / URL — without the agent having to
+know Python.
+
+Tools shipped here are **stateless**: each call takes a ``source``
+path/URL and loads the package fresh. No server-side session, no
+caching, no cross-call mutation. Stateful surfaces (editing sessions
+with rollback, indexed scope ops) would need a different design and
+are deliberately deferred to follow-up issues.
+
+Use via :func:`build_server` which returns a configured
+:class:`mcp.server.fastmcp.FastMCP`. The companion CLI command
+``datagrove mcp serve`` (not in this PR; defer to follow-up) hooks
+this into the stdio transport.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from datagrove.dataset import Package
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.server.fastmcp import FastMCP
+
+
+__all__ = ["build_server"]
+
+
+def build_server(name: str = "datagrove") -> FastMCP:
+    """Return a configured :class:`FastMCP` exposing generic datagrove tools.
+
+    The returned server is ready to ``run(transport="stdio")``. Tools:
+
+    * ``describe_package(source)`` — package metadata: table list +
+      row counts + engine name.
+    * ``validate_package(source)`` — full validation; returns the
+      :class:`~datagrove.reports.ValidationReport` as a JSON dict.
+    * ``list_tables(source)`` — short list of table names (cheap, no
+      row counts).
+
+    Args:
+        name: MCP server display name. Default ``"datagrove"``.
+
+    Returns:
+        A :class:`FastMCP` instance with the tools registered. Caller
+        invokes ``.run(transport="stdio")`` from the CLI entry point.
+
+    Examples:
+        >>> import pytest
+        >>> pytest.importorskip("mcp")
+        <module ...>
+        >>> server = build_server()
+        >>> # The server object is ready; ``server.run(...)`` would block
+        >>> # on stdio. Tests exercise the tools via the lower-level
+        >>> # registry instead.
+        >>> isinstance(server.name, str)
+        True
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP(name=name, instructions=_INSTRUCTIONS)
+
+    @server.tool(name="describe_package", description=_DESCRIBE_DOC)
+    def describe_package(source: str) -> dict[str, Any]:
+        """Return metadata about the package at ``source``."""
+        pkg = Package.from_source(source)
+        tables = []
+        for tname, table in pkg.tables.items():
+            try:
+                tables.append({"name": tname, "rows": table.count(), "columns": table.columns()})
+            except Exception:  # pragma: no cover - per-table resilience
+                tables.append({"name": tname, "rows": None, "columns": None})
+        return {
+            "source": source,
+            "name": pkg.spec.name,
+            "engine": type(pkg.engine).__name__,
+            "table_count": len(pkg.tables),
+            "tables": tables,
+        }
+
+    @server.tool(name="validate_package", description=_VALIDATE_DOC)
+    def validate_package(source: str) -> dict[str, Any]:
+        """Run full validation; return issues as a JSON-safe dict."""
+        pkg = Package.from_source(source)
+        report = pkg.validate()
+        return _report_to_dict(report)
+
+    @server.tool(name="list_tables", description=_LIST_DOC)
+    def list_tables(source: str) -> list[str]:
+        """Return the table names in the package at ``source`` (cheap, no row counts)."""
+        pkg = Package.from_source(source)
+        return sorted(pkg.tables.keys())
+
+    return server
+
+
+def _report_to_dict(report: Any) -> dict[str, Any]:
+    """Flatten a :class:`ValidationReport` to a JSON-safe dict for the MCP wire."""
+    issues = []
+    for issue in report.issues:
+        issues.append(
+            {
+                "severity": getattr(getattr(issue, "severity", None), "value", None),
+                "category": getattr(getattr(issue, "category", None), "value", None),
+                "code": getattr(issue, "code", None),
+                "message": getattr(issue, "message", None),
+                "table": getattr(issue, "table", None),
+                "column": getattr(issue, "column", None),
+                "row": getattr(issue, "row", None),
+                "fix_hint": getattr(issue, "fix_hint", None),
+            }
+        )
+    return {"issues": issues, "spec_version": getattr(report, "spec_version", None)}
+
+
+_INSTRUCTIONS = """\
+datagrove MCP server — stateless tools for any Frictionless data package.
+
+Every tool takes a ``source`` (filesystem path or URL to a package
+directory / datapackage.json file). Packages are loaded fresh per
+call; there is no session or cache.
+
+Use ``describe_package`` for a quick overview, ``list_tables`` for a
+cheap name list, and ``validate_package`` to run the full schema +
+FK + structural checks and get back a JSON-shaped report.
+"""
+
+_DESCRIBE_DOC = """\
+Return metadata about the data package at ``source``. Output includes
+the package name, engine, table count, and per-table {name, rows,
+columns} entries.
+"""
+
+_VALIDATE_DOC = """\
+Run full validation (structural + schema + foreign-key + sync-state)
+on the package at ``source``. Returns ``{issues: [...], spec_version}``
+where each issue is a dict with severity, category, code, message,
+table, column, row, fix_hint.
+"""
+
+_LIST_DOC = """\
+Return the table names (sorted) in the package at ``source``. Cheap —
+does not compute row counts; use ``describe_package`` for those.
+"""

--- a/packages/datagrove/tests/io/conftest.py
+++ b/packages/datagrove/tests/io/conftest.py
@@ -1,0 +1,32 @@
+"""Snapshot + restore the adapter registry around every io/ test.
+
+Several io/ tests mutate the module-level
+:data:`datagrove.io._REGISTRY` (clear, register fake adapters, etc.).
+Without restoration, downstream tests in later directories find an
+empty registry and can't load directory-of-csv sources.
+
+This autouse fixture snapshots the registry at test entry and
+restores it at test exit — individual tests are still free to clear /
+register inside their body; the snapshot covers the cleanup.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_adapter_registry():
+    """Snapshot + restore ``datagrove.io._REGISTRY`` / ``_BY_EXT`` / ``_BY_SCHEME``."""
+    from datagrove.io import _BY_EXT, _BY_SCHEME, _REGISTRY, _clear_registry
+
+    saved_reg = dict(_REGISTRY)
+    saved_ext = dict(_BY_EXT)
+    saved_scheme = dict(_BY_SCHEME)
+    try:
+        yield
+    finally:
+        _clear_registry()
+        _REGISTRY.update(saved_reg)
+        _BY_EXT.update(saved_ext)
+        _BY_SCHEME.update(saved_scheme)

--- a/packages/datagrove/tests/io/test_registry.py
+++ b/packages/datagrove/tests/io/test_registry.py
@@ -17,10 +17,10 @@ from ._fakes import FakeCsvAdapter, FakeParquetAdapter
 
 
 @pytest.fixture(autouse=True)
-def _isolated_registry():
+def _start_clean():
+    """Each registry test starts with a cleared registry — the io/conftest.py snapshot covers restoration."""
     _clear_registry()
     yield
-    _clear_registry()
 
 
 def test_empty_registry_after_clear() -> None:

--- a/packages/datagrove/tests/mcp/test_mcp.py
+++ b/packages/datagrove/tests/mcp/test_mcp.py
@@ -1,0 +1,94 @@
+"""Tests for the generic datagrove MCP server (task 4.11 / issue #94).
+
+We don't spin up the stdio transport — instead we introspect the
+:class:`FastMCP` instance's registered tools and call them directly
+through the same code path the protocol layer would. This keeps the
+tests fast + transport-agnostic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import asyncio
+
+from datagrove.mcp import build_server
+from gmnspy.fixtures import leavenworth
+
+
+def _call_tool(server, name: str, **kwargs):
+    """Run the registered FastMCP tool ``name`` against ``kwargs`` and return its result.
+
+    FastMCP tools are async; we wrap with ``asyncio.run`` so individual
+    tests stay sync. The internal ``_tool_manager.call_tool`` is the
+    public way to dispatch by name across SDK versions we've used.
+    """
+    return asyncio.run(server._tool_manager.call_tool(name, kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Server construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_server_returns_fastmcp_with_expected_tools():
+    """Server has the 3 generic tools registered."""
+    server = build_server()
+    tools = {t.name for t in server._tool_manager.list_tools()}
+    assert {"describe_package", "validate_package", "list_tables"} <= tools
+
+
+def test_build_server_uses_configured_name():
+    """Custom name is propagated to the FastMCP instance."""
+    assert build_server(name="my-grove").name == "my-grove"
+
+
+# ---------------------------------------------------------------------------
+# describe_package
+# ---------------------------------------------------------------------------
+
+
+def test_describe_package_returns_metadata():
+    """describe_package returns table list + row counts on Leavenworth.
+
+    Diagnostic note: directory-of-csv-files load relies on
+    :class:`Package.from_source` autosynth + the directory walk.
+    When the fixture path is relative to cwd, other tests changing
+    cwd can hide the files; we resolve to an absolute path before
+    handing it to the tool to remove that source of flakiness.
+    """
+    server = build_server()
+    source = str(leavenworth.csv_dir().resolve())
+    result = _call_tool(server, "describe_package", source=source)
+    assert result["table_count"] >= 1, f"got table_count={result['table_count']} for source={source}"
+    assert any(t["name"] == "link" for t in result["tables"])
+
+
+# ---------------------------------------------------------------------------
+# validate_package
+# ---------------------------------------------------------------------------
+
+
+def test_validate_package_returns_issues_document():
+    """validate_package returns a dict with an ``issues`` list."""
+    server = build_server()
+    result = _call_tool(server, "validate_package", source=str(leavenworth.csv_dir().resolve()))
+    assert "issues" in result
+    assert isinstance(result["issues"], list)
+
+
+# ---------------------------------------------------------------------------
+# list_tables
+# ---------------------------------------------------------------------------
+
+
+def test_list_tables_returns_sorted_names():
+    """list_tables returns a sorted list of table names."""
+    server = build_server()
+    source = str(leavenworth.csv_dir().resolve())
+    result = _call_tool(server, "list_tables", source=source)
+    assert isinstance(result, list)
+    assert result == sorted(result)
+    assert "link" in result and "node" in result, f"got tables={result} for source={source}"

--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -259,6 +259,45 @@ def _build_gmnspy_app() -> typer.Typer:
         app_instance = server_module.build_app(settings)
         uvicorn.run(app_instance, host=settings.bind, port=settings.port)
 
+    # ------------------------------------------------------------------
+    # mcp serve — stateless MCP server over stdio (task 4.11 / issue #94)
+    # ------------------------------------------------------------------
+    mcp_app = typer.Typer(no_args_is_help=True, help="Run the gmnspy MCP server for AI-agent access.")
+    gmnspy_app.add_typer(mcp_app, name="mcp")
+
+    @mcp_app.command(name="serve")
+    def mcp_serve(
+        name: str = typer.Option("gmnspy", "--name", help="MCP server display name."),
+    ) -> None:
+        """Start the gmnspy MCP server on stdio (for Claude Desktop / Claude Code).
+
+        Configure your MCP client to launch ``gmnspy mcp serve`` as a
+        subprocess (typical example:
+
+        .. code-block:: json
+
+            {"mcpServers": {"gmnspy": {"command": "gmnspy", "args": ["mcp", "serve"]}}}
+
+        ). Tools exposed: ``describe_network``, ``validate_package``,
+        ``quality_check``, ``connected_components``, ``scope_from_nodes``,
+        plus the generic datagrove tools.
+        """
+        try:
+            gmnspy_mcp = importlib.import_module("gmnspy.mcp")
+        except ImportError as e:
+            typer.secho(
+                f"gmnspy mcp requires the [mcp] extra: pip install 'gmnspy[mcp]' ({e})",
+                fg="red",
+                err=True,
+            )
+            raise typer.Exit(code=1) from None
+
+        server = gmnspy_mcp.build_server(name=name)
+        # FastMCP.run() defaults to stdio when called with no transport;
+        # stdio is what MCP-host applications expect (Claude Desktop,
+        # Claude Code, etc.).
+        server.run()
+
     return gmnspy_app
 
 

--- a/packages/gmnspy/gmnspy/mcp/__init__.py
+++ b/packages/gmnspy/gmnspy/mcp/__init__.py
@@ -1,1 +1,26 @@
-"""OPTIONAL EXTRA — MCP server for AI-agent access. Install via `pip install gmnspy[mcp]`."""
+"""OPTIONAL EXTRA — GMNS MCP server for AI-agent access (task 4.11).
+
+Install: ``pip install gmnspy[mcp]``. Run via ``gmnspy mcp serve``
+(CLI command added in this PR) which starts the FastMCP server on the
+stdio transport — point Claude Desktop or Claude Code at the binary
+via their MCP config.
+
+Tools (all stateless, take a ``source`` path/URL per call):
+
+* Generic (inherited from :mod:`datagrove.mcp`): ``describe_package``,
+  ``validate_package``, ``list_tables``.
+* GMNS-aware (added here): ``describe_network``, ``quality_check``,
+  ``connected_components``, ``scope_from_nodes``.
+
+Stateful tools — ``edit_session`` with rollback — deferred to a
+follow-up; the rollback semantics in tool form need careful design.
+"""
+
+try:
+    import mcp  # noqa: F401
+except ImportError as e:  # pragma: no cover - defensive
+    raise ImportError("gmnspy.mcp requires the [mcp] extra: pip install 'gmnspy[mcp]'") from e
+
+from .server import build_server
+
+__all__ = ["build_server"]

--- a/packages/gmnspy/gmnspy/mcp/server.py
+++ b/packages/gmnspy/gmnspy/mcp/server.py
@@ -1,0 +1,180 @@
+"""GMNS-aware MCP server (task 4.11) — composes on :mod:`datagrove.mcp`.
+
+Adds network-aware tools on top of datagrove's generic
+describe/validate/list tools:
+
+* ``describe_network(source)`` — GMNS metadata (spec_version + named
+  link/node counts), richer than the generic describe_package.
+* ``quality_check(source)`` — runs the :mod:`gmnspy.quality` rule
+  pack; returns the report as a JSON dict.
+* ``connected_components(source)`` — returns the component count +
+  sizes (uses :mod:`gmnspy.semantics.connectivity`; requires the
+  ``[clean]`` extra for igraph).
+* ``scope_from_nodes(source, node_ids, path_between)`` — applies a
+  network-aware scope and returns the resulting (node_ids, link_ids)
+  sets as lists.
+
+All tools are stateless — each call loads the network fresh. Stateful
+surfaces (editing sessions with rollback) deferred to follow-ups.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gmnspy import Network
+from gmnspy.quality import register_all
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.server.fastmcp import FastMCP
+
+
+__all__ = ["build_server"]
+
+
+def build_server(name: str = "gmnspy") -> FastMCP:
+    """Return a :class:`FastMCP` exposing GMNS-aware + generic datagrove tools.
+
+    Wraps :func:`datagrove.mcp.build_server` (so the generic tools are
+    available) then adds the network-aware tools. Caller invokes
+    ``.run(transport="stdio")`` from a CLI entry point.
+
+    Args:
+        name: Display name for the MCP server. Default ``"gmnspy"``.
+
+    Returns:
+        A configured :class:`FastMCP` ready to serve.
+
+    Examples:
+        >>> import pytest
+        >>> pytest.importorskip("mcp")
+        <module ...>
+        >>> server = build_server()
+        >>> isinstance(server.name, str)
+        True
+    """
+    from datagrove.mcp import build_server as build_generic
+    from datagrove.quality import run_quality
+
+    server = build_generic(name=name)
+
+    # Register the GMNS rule pack so quality_check has rules to run.
+    register_all()
+
+    @server.tool(name="describe_network", description=_DESCRIBE_NET_DOC)
+    def describe_network(source: str) -> dict:
+        """Return GMNS metadata for the network at ``source``."""
+        net = Network.from_source(source)
+        return {
+            "source": source,
+            "name": net.spec.name,
+            "spec_version": net.spec_version,
+            "engine": type(net.engine).__name__,
+            "links": _safe_count(net, "link"),
+            "nodes": _safe_count(net, "node"),
+            "table_count": len(net.tables),
+            "tables": sorted(net.tables.keys()),
+        }
+
+    @server.tool(name="quality_check", description=_QUALITY_DOC)
+    def quality_check(source: str) -> dict:
+        """Run the GMNS data-quality rule pack against the network at ``source``."""
+        net = Network.from_source(source)
+        report = run_quality(net)
+        return _report_to_dict(report)
+
+    @server.tool(name="connected_components", description=_COMPONENTS_DOC)
+    def connected_components_tool(source: str) -> dict:
+        """Return weakly-connected component count + sizes for the network at ``source``."""
+        from gmnspy.semantics import connected_components
+
+        net = Network.from_source(source)
+        comps = connected_components(net)
+        sizes = sorted((len(c) for c in comps), reverse=True)
+        return {"source": source, "component_count": len(comps), "sizes": sizes}
+
+    @server.tool(name="scope_from_nodes", description=_SCOPE_DOC)
+    def scope_from_nodes_tool(source: str, node_ids: list[int], path_between: bool = True) -> dict:
+        """Build a network scope from seed ``node_ids`` and return its (links, nodes) sets."""
+        from gmnspy.scope import from_nodes
+
+        net = Network.from_source(source)
+        scope = from_nodes(net, node_ids, path_between=path_between)
+        return {
+            "source": source,
+            "seed_node_ids": list(node_ids),
+            "path_between": path_between,
+            "result_node_count": len(scope.node_ids),
+            "result_link_count": len(scope.link_ids),
+            "node_ids": sorted(scope.node_ids),
+            "link_ids": sorted(scope.link_ids),
+        }
+
+    return server
+
+
+def _safe_count(net: Network, table_name: str) -> int | None:
+    """Return ``net.tables[table_name].count()`` or ``None``."""
+    table = net.tables.get(table_name)
+    if table is None:
+        return None
+    try:
+        return table.count()
+    except Exception:  # pragma: no cover
+        return None
+
+
+def _report_to_dict(report) -> dict:
+    """Flatten a :class:`ValidationReport` to a JSON-safe dict (duplicate of datagrove.mcp helper).
+
+    Intentional duplication — coupling the gmnspy MCP tools to a
+    private helper in datagrove.mcp would be tighter than the benefit.
+    The helper is 10 lines.
+    """
+    issues = []
+    for issue in report.issues:
+        issues.append(
+            {
+                "severity": getattr(getattr(issue, "severity", None), "value", None),
+                "category": getattr(getattr(issue, "category", None), "value", None),
+                "code": getattr(issue, "code", None),
+                "message": getattr(issue, "message", None),
+                "table": getattr(issue, "table", None),
+                "column": getattr(issue, "column", None),
+                "row": getattr(issue, "row", None),
+                "fix_hint": getattr(issue, "fix_hint", None),
+            }
+        )
+    return {"issues": issues, "spec_version": getattr(report, "spec_version", None)}
+
+
+_DESCRIBE_NET_DOC = """\
+Return GMNS metadata about the network at ``source``: spec_version,
+link count, node count, engine name, full table list. Richer than the
+generic ``describe_package`` — surfaces the GMNS-specific fields an
+agent typically wants up front.
+"""
+
+_QUALITY_DOC = """\
+Run the GMNS data-quality rule pack against the network at ``source``.
+Returns ``{issues: [...], spec_version}`` — each issue is a dict with
+severity (WARNING / INFO), category (always ``data_quality``), code
+(e.g. ``quality.high_speed_residential``), message, table, column,
+row, fix_hint.
+"""
+
+_COMPONENTS_DOC = """\
+Return the count + sizes of weakly-connected components in the GMNS
+network at ``source``. ``component_count == 1`` means the network is
+fully connected; ``sizes`` is the descending list of node-counts per
+component. Requires the ``[clean]`` extra (igraph).
+"""
+
+_SCOPE_DOC = """\
+Build a network scope from a list of seed ``node_ids`` and return the
+resulting set of nodes + links. ``path_between=True`` (default)
+expands the scope to include shortest-path nodes between every pair of
+seeds; ``path_between=False`` keeps just the seeds + their incident
+links. Returns ``{result_node_count, result_link_count, node_ids,
+link_ids}``.
+"""

--- a/packages/gmnspy/tests/test_mcp.py
+++ b/packages/gmnspy/tests/test_mcp.py
@@ -1,0 +1,129 @@
+"""Tests for the GMNS-aware MCP server (task 4.11 / issue #94).
+
+Same pattern as packages/datagrove/tests/mcp/test_mcp.py — introspect
+the registered tools and call them directly so we don't need an MCP
+stdio peer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp")
+pytest.importorskip("igraph")  # connected_components tool
+
+from gmnspy.fixtures import leavenworth
+from gmnspy.mcp import build_server
+
+
+def _call_tool(server, name: str, **kwargs):
+    """Synchronously dispatch a FastMCP tool by name."""
+    return asyncio.run(server._tool_manager.call_tool(name, kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Server composition
+# ---------------------------------------------------------------------------
+
+
+def test_gmns_server_inherits_generic_tools():
+    """The gmnspy MCP server still exposes the generic datagrove tools."""
+    tools = {t.name for t in build_server()._tool_manager.list_tools()}
+    assert {"describe_package", "validate_package", "list_tables"} <= tools
+
+
+def test_gmns_server_adds_network_aware_tools():
+    """The GMNS-specific tools are registered on top."""
+    tools = {t.name for t in build_server()._tool_manager.list_tools()}
+    assert {"describe_network", "quality_check", "connected_components", "scope_from_nodes"} <= tools
+
+
+# ---------------------------------------------------------------------------
+# describe_network
+# ---------------------------------------------------------------------------
+
+
+def test_describe_network_returns_gmns_metadata():
+    """describe_network surfaces spec_version + link/node counts."""
+    server = build_server()
+    r = _call_tool(server, "describe_network", source=str(leavenworth.csv_dir()))
+    assert r["spec_version"] == "0.97"
+    assert isinstance(r["links"], int) and r["links"] > 0
+    assert isinstance(r["nodes"], int) and r["nodes"] > 0
+
+
+# ---------------------------------------------------------------------------
+# quality_check
+# ---------------------------------------------------------------------------
+
+
+def test_quality_check_returns_issues_with_data_quality_category():
+    """quality_check emits the GMNS rule pack's issues."""
+    server = build_server()
+    r = _call_tool(server, "quality_check", source=str(leavenworth.csv_dir()))
+    assert "issues" in r
+    # Leavenworth fires the high-speed-residential rule.
+    codes = {i["code"] for i in r["issues"]}
+    assert "quality.high_speed_residential" in codes
+
+
+# ---------------------------------------------------------------------------
+# connected_components
+# ---------------------------------------------------------------------------
+
+
+def test_connected_components_on_leavenworth_is_one():
+    """Leavenworth is a single weakly-connected component."""
+    server = build_server()
+    r = _call_tool(server, "connected_components", source=str(leavenworth.csv_dir()))
+    assert r["component_count"] == 1
+    assert sum(r["sizes"]) == r["sizes"][0]  # all nodes in one component
+
+
+# ---------------------------------------------------------------------------
+# scope_from_nodes
+# ---------------------------------------------------------------------------
+
+
+def test_scope_from_nodes_returns_id_lists():
+    """scope_from_nodes returns subsets of (node_ids, link_ids)."""
+    server = build_server()
+    r = _call_tool(
+        server,
+        "scope_from_nodes",
+        source=str(leavenworth.csv_dir()),
+        node_ids=[1, 2],
+        path_between=False,
+    )
+    assert isinstance(r["node_ids"], list)
+    assert 1 in r["node_ids"] and 2 in r["node_ids"]
+    assert r["result_link_count"] == len(r["link_ids"])
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_subcommand_listed_in_gmnspy_help():
+    """`gmnspy --help` shows the `mcp` subcommand."""
+    from gmnspy.cli.app import app as gmnspy_cli_app
+    from typer.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(gmnspy_cli_app, ["--help"])
+    assert result.exit_code == 0
+    assert "mcp" in result.stdout
+
+
+def test_mcp_serve_help_lists_options():
+    """`gmnspy mcp serve --help` shows the --name option."""
+    from gmnspy.cli.app import app as gmnspy_cli_app
+    from typer.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(gmnspy_cli_app, ["mcp", "serve", "--help"])
+    assert result.exit_code == 0
+    assert "--name" in result.stdout


### PR DESCRIPTION
## Summary

Task 4.11 — MCP server for AI-agent access. Same composition pattern as the CLI and HTTP server.

### `datagrove.mcp` — generic stateless tools

- `build_server(name)` → `FastMCP` with `describe_package`, `validate_package`, `list_tables`.
- All tools take a `source` path/URL; load fresh per call. No session.
- `mcp` dependency loaded lazily inside `build_server()` so `import datagrove.mcp` works without the optional extra.

### `gmnspy.mcp` — GMNS-aware extension

- Optional `[mcp]` extra.
- Composes on datagrove's `build_server` then layers `describe_network`, `quality_check`, `connected_components`, `scope_from_nodes`.

### `gmnspy mcp serve` CLI

- Starts FastMCP on stdio (transport MCP hosts expect).
- Lazy-imports `gmnspy.mcp` via `importlib` so the `gmnspy.cli ↛ gmnspy.mcp` import-linter contract holds.

### Test-isolation fix (debt revealed by 4.11)

Added `packages/datagrove/tests/io/conftest.py` with an autouse snapshot-and-restore fixture for the `datagrove.io` module-level adapter registry. Previously `tests/io/test_registry.py` and `tests/io/test_dispatch.py` cleared the registry without restoring — fine in isolation but broke any later suite depending on auto-discovered adapters. Snapshot+restore is the right pattern for any module-level mutable singleton.

## Test plan

- [x] 13 new tests: `tests/mcp/test_mcp.py` × 5 + `tests/test_mcp.py` × 8.
- [x] Full suite: **818 → 831 passing**.
- [x] `ruff check` / `ruff format --check` / `lint-imports` / `lint_no_sql` all clean.

## Deferred

- `read_network` / `convert` / `edit_session` tools — `edit_session` needs careful rollback semantics in tool form; deferred to a follow-up issue.
- `query_table` with ibis-predicate-as-argument — needs wire-shape design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)