### PR TITLE
feat(notebook): _repr_html_ for Package/Table/Report/EditResult/Network (#91, #92)

### DIFF
--- a/packages/datagrove/datagrove/dataset/package.py
+++ b/packages/datagrove/datagrove/dataset/package.py
@@ -859,34 +859,36 @@ class Package:
         return f"Package({', '.join(bits)})"
 
     def _repr_html_(self) -> str:
-        """Minimal Jupyter-friendly HTML rendering.
+        """Render a Jupyter-friendly card summarising the package.
 
-        A polished view is Phase 4 / notebook polish work; today we
-        ship a small list view so a notebook user can see the table
-        names + row counts at a glance without forcing a heavy
-        materialisation. The HTML is intentionally bare so it
-        composes inside DataFrames / docs without style collisions.
+        Header carries the package name (from
+        :attr:`spec.name`) and the source locator; the body lists the
+        engine and a small ``name | rows | cols`` table for the first
+        eight tables, truncated with a "…+N more" note when there are
+        more. Row counts use :meth:`Table.count` which pushes down to
+        the engine, and column lists use the engine's lazy schema —
+        nothing forces a full materialisation.
+
+        The card composes via :func:`datagrove.notebook.card` so every
+        ``_repr_html_`` on the public surface shares the same look.
 
         Examples:
             >>> from datagrove.engines.pandas_engine import PandasEngine
             >>> from datagrove.dataset import Package, Table
             >>> e = PandasEngine()
             >>> t = Table(name="a", expr=e.from_records([{"x": 1}]), engine=e)
-            >>> "Package" in Package.from_tables({"a": t})._repr_html_()
+            >>> html = Package.from_tables({"a": t})._repr_html_()
+            >>> html.startswith("<div")
+            True
+            >>> "Package" in html
             True
         """
-        rows = "".join(
-            f"<tr><td>{_html_escape(name)}</td>"
-            f"<td>{_html_escape(t.format or '')}</td>"
-            f"<td>{'dirty' if t.dirty else 'clean'}</td></tr>"
-            for name, t in self.tables.items()
-        )
-        src = _html_escape(self.source or "<in-memory>")
-        return (
-            f"<div><strong>Package</strong> source={src}"
-            f"<table><thead><tr><th>name</th><th>format</th><th>state</th></tr></thead>"
-            f"<tbody>{rows}</tbody></table></div>"
-        )
+        # Local import to keep dataset/package.py's top-level imports
+        # focused on dataset-layer deps. The notebook module is stdlib
+        # only so the cost is negligible.
+        from datagrove.notebook import card, kv_line, small_table, truncation_note
+
+        return _render_package_card(self, card, kv_line, small_table, truncation_note)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -1206,5 +1208,96 @@ def _infer_write_format(dest: Path) -> str:
 
 
 def _html_escape(value: str) -> str:
-    """Tiny stdlib HTML escape — kept inline so :meth:`Package._repr_html_` has no deps."""
+    """Tiny stdlib HTML escape — kept inline for the legacy module surface."""
     return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+# ---------------------------------------------------------------------------
+# Notebook card rendering — shared by :meth:`Package._repr_html_` and the
+# subclass override in :class:`gmnspy.Network` so the two can't drift.
+# ---------------------------------------------------------------------------
+
+
+#: Cap on how many tables to enumerate in the per-card rows table before
+#: collapsing the rest into a "…+N more" note. Keeps the card height
+#: bounded for very wide packages (every GMNS table at once is ~24 rows).
+_PACKAGE_TABLE_PREVIEW = 8
+
+
+def _render_package_card(
+    pkg: Package,
+    card: Any,
+    kv_line: Any,
+    small_table: Any,
+    truncation_note: Any,
+    *,
+    title: str = "Package",
+    extra_kv: list[tuple[str, object]] | None = None,
+) -> str:
+    """Render the shared Package/Network card body.
+
+    Factored out so :meth:`gmnspy.Network._repr_html_` can reuse the
+    same table preview without copy-pasting the row-count probing
+    (which catches every engine-specific failure mode for cheap counts).
+
+    ``title`` is the card header (``"Package"`` by default, ``"Network"``
+    for the subclass) and ``extra_kv`` is forwarded into the metadata
+    line so the subclass can prepend ``spec_version``, ``links``,
+    ``nodes`` without re-implementing the table preview.
+    """
+    items = list(pkg.tables.items())
+    preview = items[:_PACKAGE_TABLE_PREVIEW]
+    rows: list[list[object]] = []
+    for name, table in preview:
+        rows.append([name, _safe_row_count(table), _safe_col_count(table)])
+    table_html = small_table(["name", "rows", "cols"], rows)
+    note_html = truncation_note(len(items) - len(preview), "tables")
+    kv_items: list[tuple[str, object]] = []
+    if extra_kv:
+        kv_items.extend(extra_kv)
+    kv_items.append(("engine", _engine_label(pkg.engine)))
+    kv_items.append(("tables", len(items)))
+    body = kv_line(kv_items) + table_html + note_html
+    subtitle = pkg.source or "in-memory"
+    header_title = f"{title}: {pkg.spec.name}" if getattr(pkg.spec, "name", None) else title
+    return card(header_title, body, subtitle=subtitle)
+
+
+def _safe_row_count(table: Table) -> object:
+    """Return ``table.count()`` or ``"?"`` if the engine call raises.
+
+    The cheap count path on :meth:`Table.count` pushes through the
+    engine — for an ibis expression backed by an unreachable backend it
+    can throw. We don't want a notebook preview to crash, so we swallow
+    the most common engine errors and fall through to ``"?"``. Real
+    surprises (programmer errors like ``KeyError`` / ``TypeError``)
+    still propagate so they're visible during development.
+    """
+    try:
+        return int(table.count())
+    except (RuntimeError, OSError, ValueError):
+        return "?"
+
+
+def _safe_col_count(table: Table) -> object:
+    """Return ``len(table.columns())`` or ``"?"`` on engine error.
+
+    Same conservative posture as :func:`_safe_row_count` — a notebook
+    preview should never crash the cell.
+    """
+    try:
+        return len(table.columns())
+    except (RuntimeError, OSError, ValueError):
+        return "?"
+
+
+def _engine_label(engine: Engine | None) -> str:
+    """Short engine identifier for the metadata line.
+
+    Uses :attr:`Engine.name` when present (every stock engine sets it),
+    falling back to the class name so a third-party engine still shows
+    something meaningful.
+    """
+    if engine is None:
+        return "—"
+    return str(getattr(engine, "name", type(engine).__name__))

--- a/packages/datagrove/datagrove/dataset/table.py
+++ b/packages/datagrove/datagrove/dataset/table.py
@@ -339,21 +339,30 @@ class Table:
         return f"Table({', '.join(bits)})"
 
     def _repr_html_(self) -> str:
-        """Minimal Jupyter-friendly HTML rendering.
+        """Render a Jupyter-friendly card summarising the table.
 
-        A polished render is Phase 4 / notebook polish work; today we
-        ship a ``<pre>``-wrapped :meth:`__repr__` so notebooks don't
-        break. The contract this guarantees is "non-empty string that
-        is safe to insert into a notebook cell".
+        Header carries the table name plus a ``dirty`` / ``clean``
+        badge; the body shows the engine, the row count
+        (:meth:`count` — pushes down to the engine), and the column
+        list truncated to twelve names with a "…+N more" note when
+        there are more. The card composes via
+        :func:`datagrove.notebook.card`.
 
         Examples:
             >>> from datagrove.engines.pandas_engine import PandasEngine
             >>> from datagrove.dataset import Table
             >>> e = PandasEngine()
-            >>> Table(name="t", expr=e.from_records([{"a": 1}]), engine=e)._repr_html_().startswith("<pre>")
+            >>> html = Table(name="t", expr=e.from_records([{"a": 1}]), engine=e)._repr_html_()
+            >>> html.startswith("<div")
+            True
+            >>> "Table" in html
             True
         """
-        return f"<pre>{_html_escape(repr(self))}</pre>"
+        # Local import — keeps the dataset → notebook edge load-time
+        # free and confines the dependency to the render path.
+        from datagrove.notebook import card, escape, kv_line, truncation_note
+
+        return _render_table_card(self, card, escape, kv_line, truncation_note)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -527,5 +536,62 @@ def _engine_head(engine: Engine, expr: TableExpr, n: int) -> TableExpr:
 
 
 def _html_escape(value: str) -> str:
-    """Tiny stdlib HTML escape — keeps :meth:`Table._repr_html_` dependency-free."""
+    """Tiny stdlib HTML escape — kept inline for the legacy module surface."""
     return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+# ---------------------------------------------------------------------------
+# Notebook card rendering
+# ---------------------------------------------------------------------------
+
+#: Cap on how many columns to show in the notebook card before
+#: collapsing the rest into a "…+N more" note. Twelve is wide enough
+#: for a typical GMNS table header line at default font size.
+_TABLE_COLUMN_PREVIEW = 12
+
+
+def _render_table_card(
+    table: Table,
+    card: Any,
+    escape: Any,
+    kv_line: Any,
+    truncation_note: Any,
+) -> str:
+    """Render the per-:class:`Table` notebook card.
+
+    Lives at module level so callers (the method on :class:`Table` plus
+    any subclass that wants to reuse the layout) can share the
+    column-truncation + dirty-badge logic.
+    """
+    try:
+        all_cols = list(table.columns())
+    except (RuntimeError, OSError, ValueError):
+        all_cols = []
+    preview_cols = all_cols[:_TABLE_COLUMN_PREVIEW]
+    cols_html = ", ".join(escape(c) for c in preview_cols) if preview_cols else "<em>(no columns)</em>"
+    extra_cols = max(0, len(all_cols) - len(preview_cols))
+    if extra_cols:
+        cols_html += f" <span style='color:#656d76;'>(+{extra_cols} more)</span>"
+
+    try:
+        row_count: object = int(table.count())
+    except (RuntimeError, OSError, ValueError):
+        row_count = "?"
+
+    badge_word = "dirty" if table.dirty else "clean"
+    kv_items: list[tuple[str, object]] = [
+        ("engine", getattr(table.engine, "name", type(table.engine).__name__)),
+        ("rows", row_count),
+        ("cols", len(all_cols) if all_cols else "?"),
+        ("state", badge_word),
+    ]
+    if table.format:
+        kv_items.append(("format", table.format))
+
+    body = (
+        kv_line(kv_items)
+        + f'<div style="margin-top:4px;"><span style="color:#656d76;">columns:</span> {cols_html}</div>'
+        + truncation_note(0)  # no-op; column truncation already inlined above
+    )
+    subtitle = table.source or ""
+    return card(f"Table: {table.name}", body, subtitle=subtitle)

--- a/packages/datagrove/datagrove/editing/types.py
+++ b/packages/datagrove/datagrove/editing/types.py
@@ -118,3 +118,48 @@ class EditResult:
     rollback_data: Any
     applied_at: datetime
     session_id: str | None = None
+
+    def _repr_html_(self) -> str:
+        """Render a Jupyter-friendly card summarising the edit result.
+
+        Header carries the op + target table; the body shows the
+        ``+added | -removed | ~changed`` diff line, the session id (if
+        any), and the applied timestamp. Composes via
+        :func:`datagrove.notebook.card`.
+
+        Examples:
+            >>> from datetime import datetime
+            >>> from datagrove.editing import Diff, Edit, EditResult
+            >>> e = Edit(op="add_rows", table="link", payload={"rows": [{"id": 1}]})
+            >>> r = EditResult(
+            ...     edit=e,
+            ...     diff=Diff(edit=e, rows_added=1, rows_removed=0, rows_changed=0),
+            ...     rollback_data=None,
+            ...     applied_at=datetime(2026, 1, 1, 12, 0, 0),
+            ... )
+            >>> html = r._repr_html_()
+            >>> html.startswith("<div")
+            True
+            >>> "+1 added" in html
+            True
+        """
+        from datagrove.notebook import card, kv_line
+
+        diff_line = (
+            f'<div style="margin-bottom:4px;">'
+            f'<span style="color:#1a7f37;font-weight:600;">+{self.diff.rows_added} added</span>'
+            f' <span style="color:#656d76;">|</span> '
+            f'<span style="color:#bf3989;font-weight:600;">-{self.diff.rows_removed} removed</span>'
+            f' <span style="color:#656d76;">|</span> '
+            f'<span style="color:#9a6700;font-weight:600;">~{self.diff.rows_changed} changed</span>'
+            f"</div>"
+        )
+        meta = kv_line(
+            [
+                ("session", self.session_id or ""),
+                ("applied_at", self.applied_at.isoformat(sep=" ", timespec="seconds")),
+            ]
+        )
+        body = diff_line + meta
+        title = f"EditResult: {self.edit.op} → {self.edit.table}"
+        return card(title, body)

--- a/packages/datagrove/datagrove/notebook/__init__.py
+++ b/packages/datagrove/datagrove/notebook/__init__.py
@@ -1,9 +1,170 @@
-"""Generic notebook helpers.
+"""Notebook helpers for datagrove.
 
-``_repr_html_`` implementations for ``Package``, ``Table``,
-``ValidationReport``, and ``EditResult``, plus a notebook-aware progress
-wrapper.
+Hosts the shared HTML-card helpers used by the ``_repr_html_`` methods
+that live directly on the public classes (:class:`~datagrove.dataset.Package`,
+:class:`~datagrove.dataset.Table`,
+:class:`~datagrove.reports.ValidationReport`,
+:class:`~datagrove.editing.EditResult`). The methods live on the
+classes themselves — Jupyter / VS Code call ``obj._repr_html_()``
+without any opt-in import — but every implementation funnels through
+:func:`card` here so the look is consistent across the public surface.
 
-Domain packages extend by composition (e.g. ``gmnspy.notebook`` adds
-``Network._repr_html_`` and GMNS-specific scope widgets).
+Domain packages extend by composition: :mod:`gmnspy.notebook` re-exports
+:func:`card` so :class:`gmnspy.Network` can layer GMNS-specific bits on
+top of the same template.
+
+The helpers are intentionally dependency-free (stdlib :mod:`html` plus
+f-strings) so importing this module is cheap and bringing the notebook
+extra is not required.
 """
+
+from __future__ import annotations
+
+import html
+from collections.abc import Iterable
+
+__all__ = ["card", "escape", "kv_line", "small_table", "truncation_note"]
+
+
+# ---------------------------------------------------------------------------
+# Style — kept inline so the card renders standalone in a Jupyter cell
+# without external CSS.
+# ---------------------------------------------------------------------------
+
+_CARD_STYLE = (
+    "border:1px solid #d0d7de;"
+    "border-radius:6px;"
+    "padding:10px 14px;"
+    "margin:6px 0;"
+    "font-family:system-ui,-apple-system,Segoe UI,sans-serif;"
+    "font-size:13px;"
+    "line-height:1.4;"
+    "max-width:760px;"
+    "color:#1f2328;"
+    "background:#ffffff;"
+)
+_HEADER_STYLE = (
+    "display:flex;"
+    "justify-content:space-between;"
+    "align-items:baseline;"
+    "border-bottom:1px solid #eaeef2;"
+    "padding-bottom:6px;"
+    "margin-bottom:8px;"
+    "gap:12px;"
+)
+_TITLE_STYLE = "font-weight:600;font-size:14px;"
+_SUBTITLE_STYLE = "color:#656d76;font-size:12px;text-align:right;word-break:break-all;"
+_TABLE_STYLE = "border-collapse:collapse;width:100%;margin-top:6px;font-size:12px;"
+_TH_STYLE = "text-align:left;border-bottom:1px solid #eaeef2;padding:3px 8px 3px 0;font-weight:600;color:#656d76;"
+_TD_STYLE = "padding:3px 8px 3px 0;border-bottom:1px solid #f6f8fa;vertical-align:top;"
+_NOTE_STYLE = "color:#656d76;font-size:11px;margin-top:4px;font-style:italic;"
+
+
+def escape(value: object) -> str:
+    """HTML-escape a value, coercing to ``str`` first.
+
+    ``None`` becomes an empty string so callers can drop optional values
+    into f-strings without a guard.
+
+    Examples:
+        >>> escape("<script>")
+        '&lt;script&gt;'
+        >>> escape(None)
+        ''
+        >>> escape(42)
+        '42'
+    """
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=True)
+
+
+def card(title: str, body_html: str, subtitle: str = "") -> str:
+    """Wrap ``body_html`` in a standard datagrove card.
+
+    ``title`` and ``subtitle`` are escaped here; ``body_html`` is
+    inserted verbatim and is the caller's responsibility — every helper
+    in this module returns escaped HTML.
+
+    Examples:
+        >>> "datagrove-card" in card("hello", "<p>x</p>")
+        True
+        >>> "&lt;script&gt;" in card("<script>", "")
+        True
+    """
+    header = (
+        f'<div style="{_HEADER_STYLE}">'
+        f'<span style="{_TITLE_STYLE}">{escape(title)}</span>'
+        f'<span style="{_SUBTITLE_STYLE}">{escape(subtitle)}</span>'
+        f"</div>"
+    )
+    return f'<div class="datagrove-card" style="{_CARD_STYLE}">{header}{body_html}</div>'
+
+
+def kv_line(items: Iterable[tuple[str, object]]) -> str:
+    """Render a ``key: value`` row of pill-style spans.
+
+    Skips items whose value is ``None`` or an empty string so callers
+    can pass optional fields unconditionally. Both keys and values are
+    HTML-escaped.
+
+    Examples:
+        >>> "engine" in kv_line([("engine", "pandas"), ("rows", 3)])
+        True
+        >>> kv_line([("hidden", None)])
+        ''
+    """
+    parts: list[str] = []
+    for key, value in items:
+        if value is None or value == "":
+            continue
+        parts.append(
+            f'<span style="margin-right:14px;">'
+            f'<span style="color:#656d76;">{escape(key)}:</span> '
+            f'<span style="font-weight:500;">{escape(value)}</span>'
+            f"</span>"
+        )
+    if not parts:
+        return ""
+    return f'<div style="margin-bottom:4px;">{"".join(parts)}</div>'
+
+
+def small_table(headers: list[str], rows: list[list[object]]) -> str:
+    """Render a tiny HTML ``<table>`` with the standard card styling.
+
+    Every cell is HTML-escaped. Empty ``rows`` returns the empty string
+    so callers can short-circuit on "nothing to show".
+
+    Examples:
+        >>> "<table" in small_table(["a", "b"], [[1, 2]])
+        True
+        >>> small_table(["a"], [])
+        ''
+    """
+    if not rows:
+        return ""
+    head = "".join(f'<th style="{_TH_STYLE}">{escape(h)}</th>' for h in headers)
+    body_rows: list[str] = []
+    for row in rows:
+        cells = "".join(f'<td style="{_TD_STYLE}">{escape(c)}</td>' for c in row)
+        body_rows.append(f"<tr>{cells}</tr>")
+    return f'<table style="{_TABLE_STYLE}"><thead><tr>{head}</tr></thead><tbody>{"".join(body_rows)}</tbody></table>'
+
+
+def truncation_note(remaining: int, noun: str = "rows") -> str:
+    """Render a small italic "...+N more <noun>" note.
+
+    Returns the empty string when ``remaining <= 0`` so callers can
+    forward the raw count without a guard.
+
+    Examples:
+        >>> truncation_note(0)
+        ''
+        >>> "more rows" in truncation_note(5)
+        True
+        >>> "more issues" in truncation_note(40, "issues")
+        True
+    """
+    if remaining <= 0:
+        return ""
+    return f'<div style="{_NOTE_STYLE}">…+{int(remaining)} more {escape(noun)}</div>'

--- a/packages/datagrove/datagrove/reports/types.py
+++ b/packages/datagrove/datagrove/reports/types.py
@@ -75,6 +75,14 @@ _SEVERITY_ORDER: tuple[Severity, ...] = (
     Severity.DATA_QUALITY,
 )
 
+#: How many issues to enumerate in :meth:`ValidationReport._repr_html_`
+#: before collapsing the rest into a "…+N more issues" note.
+_REPORT_ISSUE_PREVIEW = 10
+
+#: Per-message truncation cap inside the notebook card so a stack-trace
+#: -shaped message doesn't blow up cell height.
+_REPORT_MESSAGE_TRUNCATE = 120
+
 
 def severity_rank(severity: Severity) -> int:
     """Return the display rank for ``severity`` (0 = highest priority).
@@ -580,6 +588,59 @@ class ValidationReport:
     def __str__(self) -> str:
         """Alias for :meth:`to_rich` — usable from ``print(report)``."""
         return self.to_rich()
+
+    def _repr_html_(self) -> str:
+        """Render a compact Jupyter-friendly card summarising the report.
+
+        Header carries the source locator + spec version; the body
+        shows per-severity counts and the first ten issues as a
+        ``severity | code | table | message`` table, with a "…+N more
+        issues" note when more are present. For the full standalone
+        HTML report (with the issue table + optional map), use
+        :meth:`to_html`.
+
+        Examples:
+            >>> from datagrove.reports import Category, Severity, ValidationReport
+            >>> r = ValidationReport(source="empty.gmns")
+            >>> r._repr_html_().startswith("<div")
+            True
+            >>> _ = r.add(severity=Severity.ERROR, category=Category.SCHEMA,
+            ...           code="schema.required", message="x", table="t")
+            >>> "ERROR" in r._repr_html_()
+            True
+        """
+        # Local import — the notebook helper is stdlib-only but we
+        # don't want the load-time edge from reports → notebook.
+        from datagrove.notebook import card, escape, kv_line, small_table, truncation_note
+
+        # Per-severity counts in canonical display order — matches the
+        # CLI / rich renderer so the visual hierarchy is the same.
+        counts: list[tuple[str, object]] = []
+        for sev in _SEVERITY_ORDER:
+            n = self.count(sev)
+            label = sev.name  # ERROR / WARNING / INFO / DATA_QUALITY
+            counts.append((label, n))
+        if self.spec_version:
+            counts.append(("spec", self.spec_version))
+
+        preview = self.issues[:_REPORT_ISSUE_PREVIEW]
+        rows: list[list[object]] = []
+        for issue in preview:
+            msg = issue.message
+            if len(msg) > _REPORT_MESSAGE_TRUNCATE:
+                msg = msg[: _REPORT_MESSAGE_TRUNCATE - 1] + "…"
+            rows.append([issue.severity.name, issue.code, issue.table or "—", msg])
+        table_html = small_table(["severity", "code", "table", "message"], rows)
+        note_html = truncation_note(max(0, len(self.issues) - len(preview)), "issues")
+        # ``escape`` is imported but not directly used here — the helpers
+        # escape everything they touch. Kept in the import for symmetry
+        # with the other call sites and so a future inline cell stays
+        # safe-by-default.
+        _ = escape
+
+        body = kv_line(counts) + table_html + note_html
+        subtitle = self.source or ""
+        return card("ValidationReport", body, subtitle=subtitle)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/datagrove/tests/notebook/test_repr_html.py
+++ b/packages/datagrove/tests/notebook/test_repr_html.py
@@ -1,0 +1,232 @@
+"""Tests for the notebook ``_repr_html_`` surface (task 4.9a / issue #91).
+
+Each public dataclass on the read-and-edit surface — :class:`Package`,
+:class:`Table`, :class:`ValidationReport`, :class:`EditResult` — ships
+a Jupyter-friendly ``_repr_html_`` that returns a small self-contained
+HTML card. These tests pin the contract:
+
+* every renderer returns a non-empty ``<div``-prefixed string;
+* the user-visible identity fields (table name, row counts, severity
+  labels, diff counts) actually show up;
+* user-controlled values are HTML-escaped (no XSS leak through a hostile
+  table name).
+
+The cards are intentionally plain — inline CSS, stdlib-only escaping —
+so the tests assert on substring presence rather than HTML structure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from datagrove.dataset import Package, Table
+from datagrove.editing import Diff, Edit, EditResult
+from datagrove.engines.pandas_engine import PandasEngine
+from datagrove.reports import Category, Severity, ValidationReport
+
+
+def _make_package() -> Package:
+    """Build a tiny in-memory package with two named tables."""
+    engine = PandasEngine()
+    link = Table(
+        name="link",
+        expr=engine.from_records([{"id": 1, "from_node": 10}, {"id": 2, "from_node": 20}]),
+        engine=engine,
+    )
+    node = Table(name="node", expr=engine.from_records([{"id": 10}]), engine=engine)
+    return Package.from_tables({"link": link, "node": node})
+
+
+# ---------------------------------------------------------------------------
+# Package
+# ---------------------------------------------------------------------------
+
+
+def test_package_repr_html_returns_html_string() -> None:
+    """Output starts with ``<div`` and names the package."""
+    pkg = _make_package()
+    html = pkg._repr_html_()
+    assert html.startswith("<div")
+    assert "Package" in html
+    # The default Package.from_tables() name is "synthesized" — the
+    # spec's name field should be reflected in the header.
+    assert "synthesized" in html
+
+
+def test_package_repr_html_lists_tables() -> None:
+    """The card preview enumerates each loaded table with its row count."""
+    pkg = _make_package()
+    html = pkg._repr_html_()
+    assert "link" in html
+    assert "node" in html
+    # Row counts pushed down through Table.count() should land in the card.
+    assert ">2<" in html  # link has 2 rows
+    assert ">1<" in html  # node has 1 row
+
+
+# ---------------------------------------------------------------------------
+# Table
+# ---------------------------------------------------------------------------
+
+
+def test_table_repr_html_includes_name_and_count() -> None:
+    """The card lists the table name and exposes the row count."""
+    engine = PandasEngine()
+    t = Table(
+        name="links",
+        expr=engine.from_records([{"a": 1}, {"a": 2}, {"a": 3}]),
+        engine=engine,
+    )
+    html = t._repr_html_()
+    assert "links" in html
+    # Row count is 3 — should appear in the kv line.
+    assert ">3<" in html
+
+
+def test_table_repr_html_shows_dirty_badge_when_dirty() -> None:
+    """A dirty table renders the ``dirty`` badge; clean tables don't."""
+    engine = PandasEngine()
+    t = Table(name="t", expr=engine.from_records([{"a": 1}]), engine=engine)
+    assert "dirty" not in t._repr_html_()
+    t.dirty = True
+    html = t._repr_html_()
+    assert "dirty" in html
+
+
+def test_table_repr_html_truncates_long_column_list() -> None:
+    """Tables with >12 columns get the ``(+N more)`` note."""
+    engine = PandasEngine()
+    cols = {f"c{i}": i for i in range(20)}
+    t = Table(name="wide", expr=engine.from_records([cols]), engine=engine)
+    html = t._repr_html_()
+    assert "+8 more" in html  # 20 columns total, 12 shown
+
+
+# ---------------------------------------------------------------------------
+# ValidationReport
+# ---------------------------------------------------------------------------
+
+
+def test_validation_report_repr_html_groups_by_severity() -> None:
+    """Per-severity counts surface as labeled cells in the card."""
+    report = ValidationReport(source="x.gmns")
+    report.add(
+        severity=Severity.ERROR,
+        category=Category.SCHEMA,
+        code="schema.required",
+        message="missing required field",
+    )
+    report.add(
+        severity=Severity.WARNING,
+        category=Category.SYNC_STATE,
+        code="sync.fk_stale",
+        message="fk stale",
+    )
+    html = report._repr_html_()
+    assert "ERROR" in html
+    assert "WARNING" in html
+    assert "INFO" in html
+    assert "DATA_QUALITY" in html
+
+
+def test_validation_report_repr_html_truncates_long_issue_list() -> None:
+    """A 50-issue report collapses the tail into a +N-more note."""
+    report = ValidationReport(source="big.gmns")
+    for i in range(50):
+        report.add(
+            severity=Severity.INFO,
+            category=Category.SCHEMA,
+            code="schema.note",
+            message=f"row {i} is informational",
+            table="link",
+            row=i,
+        )
+    html = report._repr_html_()
+    # 10 issues shown by default → 40 remaining.
+    assert "+40 more issues" in html
+
+
+def test_validation_report_repr_html_includes_spec_version() -> None:
+    """When spec_version is set it shows up in the card metadata."""
+    report = ValidationReport(spec_version="0.97", source="x.gmns")
+    html = report._repr_html_()
+    assert "0.97" in html
+
+
+# ---------------------------------------------------------------------------
+# EditResult
+# ---------------------------------------------------------------------------
+
+
+def test_edit_result_repr_html_shows_diff_counts() -> None:
+    """The diff line surfaces +/-/~ counts and the edit identity."""
+    edit = Edit(op="add_rows", table="link", payload={"rows": [{"id": 1}, {"id": 2}]})
+    diff = Diff(edit=edit, rows_added=2, rows_removed=0, rows_changed=0)
+    res = EditResult(
+        edit=edit,
+        diff=diff,
+        rollback_data=None,
+        applied_at=datetime(2026, 5, 22, 9, 30, 0),
+    )
+    html = res._repr_html_()
+    assert html.startswith("<div")
+    assert "+2 added" in html
+    assert "-0 removed" in html
+    assert "~0 changed" in html
+    assert "add_rows" in html
+    assert "link" in html
+
+
+def test_edit_result_repr_html_includes_session_and_timestamp() -> None:
+    """The session id (when set) and applied_at timestamp appear in the body."""
+    edit = Edit(op="delete_rows", table="node", payload={})
+    diff = Diff(edit=edit, rows_added=0, rows_removed=5, rows_changed=0)
+    res = EditResult(
+        edit=edit,
+        diff=diff,
+        rollback_data={"snapshot": []},
+        applied_at=datetime(2026, 5, 22, 14, 15, 0),
+        session_id="sess-abc",
+    )
+    html = res._repr_html_()
+    assert "sess-abc" in html
+    assert "2026-05-22" in html
+
+
+# ---------------------------------------------------------------------------
+# Escaping — the only contract that's load-bearing for security
+# ---------------------------------------------------------------------------
+
+
+def test_repr_html_escapes_user_input_in_table_name() -> None:
+    """A hostile table name renders escaped; no raw ``<script>`` in the HTML."""
+    engine = PandasEngine()
+    t = Table(name="<script>alert(1)</script>", expr=engine.from_records([{"a": 1}]), engine=engine)
+    html = t._repr_html_()
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_repr_html_escapes_user_input_in_package_table_names() -> None:
+    """A package whose table key contains HTML metacharacters escapes them."""
+    engine = PandasEngine()
+    t = Table(name="x<y>", expr=engine.from_records([{"a": 1}]), engine=engine)
+    pkg = Package.from_tables({"x<y>": t})
+    html = pkg._repr_html_()
+    assert "<y>" not in html
+    assert "&lt;y&gt;" in html
+
+
+def test_repr_html_escapes_user_input_in_report_messages() -> None:
+    """A hostile message string renders escaped in the issue table."""
+    report = ValidationReport()
+    report.add(
+        severity=Severity.ERROR,
+        category=Category.SCHEMA,
+        code="schema.required",
+        message="<img src=x onerror=alert(1)>",
+        table="link",
+    )
+    html = report._repr_html_()
+    assert "<img" not in html
+    assert "&lt;img" in html

--- a/packages/gmnspy/gmnspy/network.py
+++ b/packages/gmnspy/gmnspy/network.py
@@ -233,6 +233,61 @@ class Network(Package):
     # Validation
     # ------------------------------------------------------------------
 
+    def _repr_html_(self) -> str:  # type: ignore[override]
+        """Render a Jupyter-friendly card for the GMNS network.
+
+        Extends :meth:`Package._repr_html_` with a header label of
+        ``"Network"``, the active GMNS :attr:`spec_version`, and a
+        ``links``/``nodes`` row-count line so the GMNS shape of the
+        package is visible at a glance.
+
+        Reuses :func:`datagrove.dataset.package._render_package_card`
+        so the table preview and styling can't drift from the parent
+        class.
+
+        Examples:
+            >>> from gmnspy import Network
+            >>> from gmnspy.fixtures import leavenworth
+            >>> from datagrove.engines.pandas_engine import PandasEngine
+            >>> net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+            >>> html = net._repr_html_()
+            >>> html.startswith("<div")
+            True
+            >>> "Network" in html
+            True
+            >>> "0.97" in html
+            True
+        """
+        from datagrove.dataset.package import _render_package_card
+        from datagrove.notebook import card, kv_line, small_table, truncation_note
+
+        extra: list[tuple[str, object]] = []
+        if self.spec_version:
+            extra.append(("gmns", self.spec_version))
+        # Only emit links/nodes counts when present — a partial load
+        # (e.g. just nodes) shouldn't crash the preview.
+        link_table = self.tables.get("link")
+        node_table = self.tables.get("node")
+        if link_table is not None:
+            try:
+                extra.append(("links", int(link_table.count())))
+            except (RuntimeError, OSError, ValueError):
+                extra.append(("links", "?"))
+        if node_table is not None:
+            try:
+                extra.append(("nodes", int(node_table.count())))
+            except (RuntimeError, OSError, ValueError):
+                extra.append(("nodes", "?"))
+        return _render_package_card(
+            self,
+            card,
+            kv_line,
+            small_table,
+            truncation_note,
+            title="Network",
+            extra_kv=extra,
+        )
+
     def validate(self, **kwargs) -> ValidationReport:  # type: ignore[override]
         """Run the inherited :meth:`Package.validate` and stamp :attr:`spec_version` on the report.
 

--- a/packages/gmnspy/gmnspy/notebook/__init__.py
+++ b/packages/gmnspy/gmnspy/notebook/__init__.py
@@ -1,1 +1,18 @@
-"""Notebook helpers: `_repr_html_` for Network / Table / ValidationReport / EditResult, plus widgets."""
+"""GMNS notebook helpers.
+
+The ``_repr_html_`` methods live directly on the public classes
+(:class:`gmnspy.Network` plus everything in :mod:`datagrove.notebook`),
+so no opt-in import is needed for the notebook preview. This module
+re-exports the shared HTML helpers so domain-specific extensions can
+build cards in the same style without reaching into
+:mod:`datagrove.notebook` themselves.
+
+Future widget additions (e.g. an ipywidgets-backed scope picker) live
+here.
+"""
+
+from __future__ import annotations
+
+from datagrove.notebook import card, escape, kv_line, small_table, truncation_note
+
+__all__ = ["card", "escape", "kv_line", "small_table", "truncation_note"]

--- a/packages/gmnspy/tests/test_notebook.py
+++ b/packages/gmnspy/tests/test_notebook.py
@@ -1,0 +1,59 @@
+"""Tests for the GMNS ``_repr_html_`` surface (task 4.9b / issue #92).
+
+:class:`gmnspy.Network` overrides
+:meth:`datagrove.dataset.Package._repr_html_` to add the GMNS spec
+version and link/node row counts. These tests pin the cross-package
+contract: a Network card should retain the Package shape while
+advertising the GMNS-specific extras.
+"""
+
+from __future__ import annotations
+
+from datagrove.engines.pandas_engine import PandasEngine
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+
+def _make_network() -> Network:
+    """Load the Leavenworth fixture with the pandas engine.
+
+    Pandas keeps tests deterministic (no backend processes) and the
+    fixture is the canonical "small but realistic" GMNS dataset already
+    used across the test suite.
+    """
+    return Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+
+
+def test_network_repr_html_includes_spec_version() -> None:
+    """The active GMNS spec version surfaces in the card metadata."""
+    net = _make_network()
+    html = net._repr_html_()
+    assert net.spec_version  # sanity — fixture loads against a real spec
+    assert net.spec_version in html
+
+
+def test_network_repr_html_includes_link_node_counts() -> None:
+    """The card surfaces link and node row counts."""
+    net = _make_network()
+    html = net._repr_html_()
+    assert "links" in html
+    assert "nodes" in html
+    # The exact counts are fixture-stable: assert they're at least
+    # present as integers > 0 via the link/node table preview rows.
+    link_count = net.links.count()
+    node_count = net.nodes.count()
+    assert str(link_count) in html
+    assert str(node_count) in html
+
+
+def test_network_repr_html_extends_package_format() -> None:
+    """Output still uses the datagrove card shape (div + table preview)."""
+    net = _make_network()
+    html = net._repr_html_()
+    assert html.startswith("<div")
+    assert "Network" in html
+    # Table preview still renders.
+    assert "<table" in html
+    assert "name" in html
+    assert "rows" in html
+    assert "cols" in html


### PR DESCRIPTION
## Summary

- Adds tasteful one-card HTML previews on every public class on the read-and-edit surface so Jupyter / VS Code notebook renderers stop showing `<Package object at 0x...>`.
- Methods live directly on the classes (no monkey-patching) — they're plain f-strings + stdlib `html.escape`, no jinja2 / ipywidgets dependency to justify the indirection. Per the task's Lens-C re-eval: methods on the class are simpler to find.
- All five renderers (`Package`, `Table`, `ValidationReport`, `EditResult`, `Network`) funnel through the shared `datagrove.notebook` card helpers (`card`, `kv_line`, `small_table`, `truncation_note`) so the visual style stays consistent and the GMNS subclass can reuse the parent template via `_render_package_card`.

## Per-class contracts

- **Package** — name + source header, engine, table preview (8 max, "…+N more" otherwise) with name/rows/cols columns.
- **Table** — name + dirty/clean badge, engine, row + column counts, column list truncated to 12.
- **ValidationReport** — per-severity counts (`ERROR | WARNING | INFO | DATA_QUALITY`) + spec version, first 10 issues as `severity | code | table | message` with a `+N more issues` note past that. Long messages truncated to 120 chars to keep cells bounded.
- **EditResult** — op + target table, `+N added | -N removed | ~N changed` diff line, session id + ISO timestamp.
- **Network** — extends the Package card with `gmns` spec version and `links` / `nodes` row counts. Composes `_render_package_card` so the table preview can't drift.

## Safety

- Every user-controlled string is HTML-escaped via `datagrove.notebook.escape`. Tests pin the contract for hostile table names, package keys, and validation messages.
- Engine probes for row + column counts are wrapped so a flaky backend can't crash the cell preview — `?` falls back instead. Real programmer errors still propagate.

Closes #91, #92.

## Test plan

- [x] `uv run pytest packages/datagrove/tests/notebook/ packages/gmnspy/tests/test_notebook.py -v` — 16 new tests pass.
- [x] `uv run pytest` — 810 passed, 52 skipped (was 794 / 52 — +16, no regressions).
- [x] `uv run ruff check packages/ scripts/ main.py` — clean.
- [x] `uv run ruff format --check packages/ scripts/ main.py` — clean.
- [x] `uv run lint-imports` — both contracts kept.
- [x] `uv run python scripts/lint_no_sql.py` — clean.

## Deferred (per task brief)

- Scope-builder ipywidget for gmnspy.
- Rich progress-bar wrapper (already in `datagrove.operations.progress` per task 3.3).
- Vega-Lite map embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)