### PR TITLE
feat(cli): gmnspy clean/scope/index commands (#88)

### DIFF
--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -298,6 +298,269 @@ def _build_gmnspy_app() -> typer.Typer:
         # Claude Code, etc.).
         server.run()
 
+    # ------------------------------------------------------------------
+    # clean — network-editing ops (task 4.6 / issue #88)
+    # ------------------------------------------------------------------
+    #
+    # Each subcommand wraps an op from :mod:`gmnspy.clean` (optional
+    # ``[clean]`` extra). The op runs inside a :class:`Session` so we
+    # get atomic rollback + a diff to show; ``--dry-run`` rolls back
+    # before write so the on-disk network is unchanged. Without
+    # ``--dest`` the modified network is written back over ``source``;
+    # with ``--dest`` it goes to the given path (mirroring the
+    # ``gmnspy info``/``validate`` convention of leaving the source
+    # alone when the caller asks for somewhere else).
+    clean_app = typer.Typer(no_args_is_help=True, help="GMNS network-editing ops (requires the 'clean' extra).")
+    gmnspy_app.add_typer(clean_app, name="clean")
+
+    @clean_app.command(name="simplify-geometry")
+    def clean_simplify(
+        source: Path = typer.Argument(..., help="Path to the GMNS network to edit."),
+        dest: Path = typer.Option(
+            None, "--dest", help="Where to write the modified network. Default: overwrite source."
+        ),
+        mode: str = typer.Option("redundant_only", "--mode", help="redundant_only or douglas_peucker."),
+        tolerance: float = typer.Option(0.0, "--tolerance", help="Tolerance in CRS units (douglas_peucker only)."),
+        engine: str = typer.Option(None, "--engine", help="ibis/pandas/polars (default: ibis)."),
+        dry_run: bool = typer.Option(False, "--dry-run", help="Print what would change; do not write."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Simplify link geometries on the network at ``source``."""
+        clean = _import_clean()
+        net, Session = _load_network_and_session_cls(source, engine)
+        with Session(net) as session:
+            result = clean.simplify_geometry(net, session, mode=mode, tolerance=tolerance)
+            summary = _summarise_results(result, op="simplify_geometry", source=source, dest=dest, dry_run=dry_run)
+            if dry_run:
+                session.rollback()
+            else:
+                _write_network(net, source=source, dest=dest)
+        render_dict(summary, json_out=json_out, title=f"gmnspy clean simplify-geometry: {source}")
+
+    @clean_app.command(name="merge-close-nodes")
+    def clean_merge(
+        source: Path = typer.Argument(..., help="Path to the GMNS network to edit."),
+        dest: Path = typer.Option(
+            None, "--dest", help="Where to write the modified network. Default: overwrite source."
+        ),
+        threshold_m: float = typer.Option(5.0, "--threshold-m", help="Distance threshold in node CRS units."),
+        engine: str = typer.Option(None, "--engine", help="ibis/pandas/polars (default: ibis)."),
+        dry_run: bool = typer.Option(False, "--dry-run", help="Print what would change; do not write."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Merge node pairs within ``--threshold-m`` of each other; rewrite incident links."""
+        clean = _import_clean()
+        net, Session = _load_network_and_session_cls(source, engine)
+        with Session(net) as session:
+            results = clean.merge_close_nodes(net, session, threshold_m=threshold_m)
+            summary = _summarise_results(results, op="merge_close_nodes", source=source, dest=dest, dry_run=dry_run)
+            if dry_run:
+                session.rollback()
+            else:
+                _write_network(net, source=source, dest=dest)
+        render_dict(summary, json_out=json_out, title=f"gmnspy clean merge-close-nodes: {source}")
+
+    @clean_app.command(name="remove-orphans")
+    def clean_remove_orphans(
+        source: Path = typer.Argument(..., help="Path to the GMNS network to edit."),
+        dest: Path = typer.Option(
+            None, "--dest", help="Where to write the modified network. Default: overwrite source."
+        ),
+        engine: str = typer.Option(None, "--engine", help="ibis/pandas/polars (default: ibis)."),
+        dry_run: bool = typer.Option(False, "--dry-run", help="Print what would change; do not write."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Drop nodes with no incident links."""
+        clean = _import_clean()
+        net, Session = _load_network_and_session_cls(source, engine)
+        with Session(net) as session:
+            result = clean.remove_orphans(net, session)
+            summary = _summarise_results(result, op="remove_orphans", source=source, dest=dest, dry_run=dry_run)
+            if dry_run:
+                session.rollback()
+            else:
+                _write_network(net, source=source, dest=dest)
+        render_dict(summary, json_out=json_out, title=f"gmnspy clean remove-orphans: {source}")
+
+    @clean_app.command(name="recompute-lengths")
+    def clean_recompute_lengths(
+        source: Path = typer.Argument(..., help="Path to the GMNS network to edit."),
+        dest: Path = typer.Option(
+            None, "--dest", help="Where to write the modified network. Default: overwrite source."
+        ),
+        geodesic: bool = typer.Option(False, "--geodesic", help="Compute haversine length in meters (WGS84)."),
+        engine: str = typer.Option(None, "--engine", help="ibis/pandas/polars (default: ibis)."),
+        dry_run: bool = typer.Option(False, "--dry-run", help="Print what would change; do not write."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Recompute ``link.length`` from the inline geometry column."""
+        clean = _import_clean()
+        net, Session = _load_network_and_session_cls(source, engine)
+        with Session(net) as session:
+            result = clean.recompute_lengths(net, session, geodesic=geodesic)
+            summary = _summarise_results(result, op="recompute_lengths", source=source, dest=dest, dry_run=dry_run)
+            if dry_run:
+                session.rollback()
+            else:
+                _write_network(net, source=source, dest=dest)
+        render_dict(summary, json_out=json_out, title=f"gmnspy clean recompute-lengths: {source}")
+
+    # ------------------------------------------------------------------
+    # scope — network-aware scope ops (task 4.6 / issue #88)
+    # ------------------------------------------------------------------
+    #
+    # Read-only: each subcommand builds a :class:`NetworkScope` from a
+    # seed and prints {node_count, link_count, node_ids, link_ids}.
+    # ``gmnspy.scope`` is part of core (no extra needed) but the
+    # underlying :class:`GraphIndex` requires igraph (the [clean]
+    # extra) — surface a typed error if igraph is absent.
+    scope_app = typer.Typer(no_args_is_help=True, help="Build a NetworkScope and print its (links, nodes) sets.")
+    gmnspy_app.add_typer(scope_app, name="scope")
+
+    @scope_app.command(name="from-nodes")
+    def scope_from_nodes_cmd(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        node_ids: list[int] = typer.Argument(..., help="Seed node ids."),
+        path_between: bool = typer.Option(True, "--path-between/--no-path-between"),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Build a scope from seed node ids and print its (links, nodes) sets."""
+        scope_mod = _import_scope()
+        net = Network.from_source(source)
+        with _scope_errors():
+            scope = scope_mod.from_nodes(net, node_ids, path_between=path_between)
+        render_dict(_summarise_scope(scope), json_out=json_out, title=f"gmnspy scope from-nodes: {source}")
+
+    @scope_app.command(name="from-node")
+    def scope_from_node_cmd(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        node_id: int = typer.Argument(..., help="Seed node id."),
+        network_buffer: str = typer.Option(
+            "0.5mi", "--network-buffer", help="Distance with unit (e.g. '0.5mi', '800m')."
+        ),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Scope = all nodes within ``--network-buffer`` network-distance of ``node_id``."""
+        scope_mod = _import_scope()
+        net = Network.from_source(source)
+        with _scope_errors():
+            scope = scope_mod.from_node(net, node_id, network_buffer=network_buffer)
+        render_dict(_summarise_scope(scope), json_out=json_out, title=f"gmnspy scope from-node: {source}")
+
+    @scope_app.command(name="connected-component")
+    def scope_connected_component_cmd(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        seed_node_id: int = typer.Argument(..., help="Seed node id whose component to return."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Scope = the weakly-connected component containing ``seed_node_id``."""
+        scope_mod = _import_scope()
+        net = Network.from_source(source)
+        with _scope_errors():
+            scope = scope_mod.connected_component(net, seed_node_id)
+        render_dict(_summarise_scope(scope), json_out=json_out, title=f"gmnspy scope connected-component: {source}")
+
+    @scope_app.command(name="from-zone")
+    def scope_from_zone_cmd(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        zone_ids: list[int] = typer.Argument(..., help="Zone ids whose nodes (+ incident links) to include."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Scope = all nodes with ``zone_id`` in ``zone_ids`` plus their incident links."""
+        scope_mod = _import_scope()
+        net = Network.from_source(source)
+        with _scope_errors():
+            scope = scope_mod.from_zone(net, zone_ids)
+        render_dict(_summarise_scope(scope), json_out=json_out, title=f"gmnspy scope from-zone: {source}")
+
+    # ------------------------------------------------------------------
+    # index — spatial + graph index build/status/drop (task 4.6 / issue #88)
+    # ------------------------------------------------------------------
+    #
+    # Sidecars land under ``<source.parent>/_gmnspy_indexes/`` per
+    # :func:`gmnspy.indexes.cache.cache_path`. ``build`` content-hashes
+    # the link table (and node table for the graph index) so a re-build
+    # over identical data is a cheap no-op.
+    index_app = typer.Typer(no_args_is_help=True, help="Spatial + graph index build/status/drop.")
+    gmnspy_app.add_typer(index_app, name="index")
+
+    @index_app.command(name="build")
+    def index_build(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        spatial: bool = typer.Option(True, "--spatial/--no-spatial"),
+        graph: bool = typer.Option(True, "--graph/--no-graph"),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Build spatial + graph indexes for the network at ``source``; cache to disk."""
+        indexes = _import_indexes()
+        net = Network.from_source(source)
+        # Spatial index needs an inline ``geometry`` column on links;
+        # auto-skip (with a logged note) rather than crashing so the
+        # default ``build`` works on geometry-table-backed networks too.
+        # Callers wanting to assemble + index in one go should run
+        # :func:`gmnspy.semantics.assemble_link_geometry` first.
+        skipped_spatial = False
+        if spatial and "geometry" not in net.links.columns():
+            spatial = False
+            skipped_spatial = True
+        with _scope_errors():
+            spatial_idx, graph_idx = indexes.build_indexes(
+                links=net.links,
+                nodes=net.nodes if graph else None,
+                spatial=spatial,
+                graph=graph,
+            )
+        paths: list[str] = []
+        if spatial_idx is not None:
+            p = _save_index_sidecar(indexes, source, net, "spatial", spatial_idx, kind_target="link")
+            paths.append(str(p))
+        if graph_idx is not None:
+            p = _save_index_sidecar(indexes, source, net, "graph", graph_idx, kind_target="link+node")
+            paths.append(str(p))
+        summary = {
+            "source": str(source),
+            "spatial": spatial_idx is not None,
+            "graph": graph_idx is not None,
+            "paths": paths,
+            "skipped_spatial_no_geometry": skipped_spatial,
+        }
+        render_dict(summary, json_out=json_out, title=f"gmnspy index build: {source}")
+
+    @index_app.command(name="status")
+    def index_status(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Report which index sidecars exist next to ``source``."""
+        paths = _list_index_sidecars(source)
+        summary = {
+            "source": str(source),
+            "spatial": any(".spatial." in p.name for p in paths),
+            "graph": any(".graph." in p.name for p in paths),
+            "paths": [str(p) for p in paths],
+        }
+        render_dict(summary, json_out=json_out, title=f"gmnspy index status: {source}")
+
+    @index_app.command(name="drop")
+    def index_drop(
+        source: Path = typer.Argument(..., help="Path to the GMNS network."),
+        json_out: bool = typer.Option(False, "--json", help="Emit JSON on stdout."),
+    ) -> None:
+        """Delete cached spatial + graph sidecars next to ``source``."""
+        paths = _list_index_sidecars(source)
+        removed: list[str] = []
+        for p in paths:
+            try:
+                p.unlink()
+                removed.append(str(p))
+            except OSError:  # pragma: no cover - race; surface but don't crash
+                continue
+        render_dict(
+            {"source": str(source), "removed": removed, "count": len(removed)},
+            json_out=json_out,
+            title=f"gmnspy index drop: {source}",
+        )
+
     return gmnspy_app
 
 
@@ -481,6 +744,179 @@ def _check_leavenworth_loads() -> dict[str, object]:
             "ok": False,
             "detail": f"{exc.__class__.__name__}: {exc}",
         }
+
+
+# ---------------------------------------------------------------------------
+# clean / scope / index helpers (task 4.6 / issue #88)
+# ---------------------------------------------------------------------------
+#
+# Optional-extra resolution goes through importlib so the import-linter
+# contract ``gmnspy.cli ↛ gmnspy.clean`` (and the corollary for the
+# scope/index ops needing igraph) holds; the contract is enforced on
+# static imports only, so runtime discovery is the architecture-blessed
+# path. Each ``_import_*`` helper exits non-zero with the install hint
+# when the extra is missing — same shape as ``gmnspy server run``.
+
+
+def _import_clean():
+    """Resolve :mod:`gmnspy.clean` at call time so the import-linter contract holds."""
+    try:
+        return importlib.import_module("gmnspy.clean")
+    except ImportError as e:
+        typer.secho(
+            f"gmnspy clean requires the [clean] extra: pip install 'gmnspy[clean]' ({e})",
+            fg="red",
+            err=True,
+        )
+        raise typer.Exit(code=1) from None
+
+
+def _import_scope():
+    """Resolve :mod:`gmnspy.scope` — core module but its index ops need igraph."""
+    return importlib.import_module("gmnspy.scope")
+
+
+def _import_indexes():
+    """Resolve :mod:`gmnspy.indexes` — core module but build needs igraph + shapely at call time."""
+    return importlib.import_module("gmnspy.indexes")
+
+
+def _load_network_and_session_cls(source: Path, engine_name: str | None = None):
+    """Return ``(Network, Session class)`` — :class:`Session` lives in datagrove, imported here so each op is one-line.
+
+    ``engine_name`` follows the same ibis/pandas/polars resolution as
+    :func:`_resolve_engine`. Callers can override the default ibis
+    engine to dodge backend-specific edge cases (e.g. duckdb refusing
+    null-typed columns when re-materialising via ``engine.from_records``
+    during a ``replace_table`` edit on a fixture that carries empty
+    string columns typed as null).
+    """
+    from datagrove.editing import Session
+
+    return Network.from_source(source, engine=_resolve_engine(engine_name)), Session
+
+
+def _summarise_results(results, *, op: str, source: Path, dest: Path | None, dry_run: bool) -> dict[str, object]:
+    """Render an :class:`EditResult` (or list thereof) into the CLI's standard summary dict."""
+    if not isinstance(results, list):
+        results = [results]
+    return {
+        "op": op,
+        "source": str(source),
+        "dest": str(dest) if dest is not None else str(source),
+        "dry_run": dry_run,
+        "edits": [
+            {
+                "table": r.edit.table,
+                "op": r.edit.op,
+                "rows_added": r.diff.rows_added,
+                "rows_removed": r.diff.rows_removed,
+                "rows_changed": r.diff.rows_changed,
+            }
+            for r in results
+        ],
+    }
+
+
+def _write_network(net: Network, *, source: Path, dest: Path | None) -> None:
+    """Write ``net`` back to ``dest`` (or ``source`` when ``dest`` is None).
+
+    Uses :meth:`Package.write`; the format is inferred from the
+    target's extension, falling back to ``parquet`` for directory
+    targets — matches the read-path convention so a round-trip lands
+    the same logical package.
+
+    Suppresses :class:`OutOfSyncWarning` (raised by the dirty tracker
+    on tables we just edited). The whole point of these CLI ops is
+    "edit then write" — the dirty flag is expected, and the warning
+    would be promoted to an error under the project's
+    ``filterwarnings = ["error"]`` pytest config.
+    """
+    import warnings
+
+    from datagrove.dataset.package import OutOfSyncWarning
+
+    target = dest if dest is not None else source
+    overwrite = target.exists()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", OutOfSyncWarning)
+        net.write(target, overwrite=overwrite)
+
+
+class _ScopeErrors:
+    """Context manager that converts library errors (ScopeError / ImportError) into typer.Exit(1) with a clean message.
+
+    Class form (not a function-decorated ``contextlib.contextmanager``)
+    so ``typer`` sees ``with _scope_errors():`` as a regular block — no
+    generator-induced surprises around its exception handling.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            return False
+        # ScopeError or any sibling gmnspy error — surface the message
+        # rather than the full traceback (the user typed a CLI command).
+        if issubclass(exc_type, ImportError):
+            typer.secho(
+                f"missing optional extra: {exc_val} (try `pip install 'gmnspy[clean]'`)",
+                fg="red",
+                err=True,
+            )
+            raise typer.Exit(code=1) from None
+        # gmnspy.scope.ScopeError / gmnspy.clean.CleanError both subclass
+        # gmnspy.NetworkError; catch by name to avoid importing the optional
+        # modules just to register the class hierarchy here.
+        if exc_type.__name__ in {"ScopeError", "CleanError", "NetworkError", "ValueError"}:
+            typer.secho(f"error: {exc_val}", fg="red", err=True)
+            raise typer.Exit(code=1) from None
+        return False  # let everything else propagate (real bugs, KeyboardInterrupt, …)
+
+
+def _scope_errors() -> _ScopeErrors:
+    """Return the shared error-conversion context manager."""
+    return _ScopeErrors()
+
+
+def _summarise_scope(scope) -> dict[str, object]:
+    """Render a :class:`NetworkScope` into the CLI's standard summary dict."""
+    return {
+        "node_count": len(scope.node_ids),
+        "link_count": len(scope.link_ids),
+        "node_ids": sorted(scope.node_ids),
+        "link_ids": sorted(scope.link_ids),
+        "provenance": scope.provenance,
+    }
+
+
+def _save_index_sidecar(indexes, source: Path, net: Network, kind: str, index_obj, *, kind_target: str) -> Path:
+    """Hash the relevant source table(s), compute the sidecar path, write the index."""
+    from datagrove.validation import hash_table
+
+    if kind_target == "link":
+        content_hash = hash_table(net.links.expr, net.engine)
+    else:
+        # graph index keys off both links + nodes — combine the digests
+        # by hashing the concatenation; only the first 8 chars land in
+        # the filename anyway (see cache_path docstring).
+        import hashlib
+
+        link_h = hash_table(net.links.expr, net.engine)
+        node_h = hash_table(net.nodes.expr, net.engine)
+        content_hash = hashlib.sha256(f"{link_h}::{node_h}".encode()).hexdigest()
+    path = indexes.cache_path(str(source), kind, content_hash)
+    indexes.save_cached(path, index_obj)
+    return path
+
+
+def _list_index_sidecars(source: Path) -> list[Path]:
+    """Return sorted sidecar parquet files for the network at ``source`` (empty list when none)."""
+    sidecar_dir = source.parent / "_gmnspy_indexes"
+    if not sidecar_dir.is_dir():
+        return []
+    return sorted(sidecar_dir.glob(f"{source.stem}.*.parquet"))
 
 
 def _check_auto_approve_env() -> dict[str, object]:

--- a/packages/gmnspy/tests/test_cli_clean_scope_index.py
+++ b/packages/gmnspy/tests/test_cli_clean_scope_index.py
@@ -1,0 +1,247 @@
+"""Tests for ``gmnspy clean / scope / index`` CLI commands (task 4.6 / issue #88).
+
+Each sub-app wraps an existing programmatic API. These tests cover the
+plumbing: exit codes, JSON shape, dry-run safety, and that
+``--help`` advertises the new top-level commands so a user can find
+them. The ops themselves are exercised in ``test_clean.py`` /
+``test_scope.py`` / ``test_indexes_cache.py`` — this file does **not**
+re-test the underlying behaviour.
+
+The Leavenworth fixture's ``node`` table carries an empty ``name``
+column that ibis types as null, which DuckDB refuses to round-trip
+through ``replace_table``. So the clean tests pass ``--engine pandas``
+to dodge a backend-specific edge case unrelated to the CLI surface
+under test. The same fixture has no inline ``geometry`` column on
+links, which the index ``build`` step gracefully degrades around.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from gmnspy.cli.app import app
+from gmnspy.fixtures import leavenworth
+from typer.testing import CliRunner
+
+# clean + index ops both require shapely + igraph (the ``[clean]`` extra).
+# Scope's graph-aware ops need igraph too. Skip wholesale if missing — the
+# extras are part of the dev environment but a slim install will skip.
+pytest.importorskip("shapely")
+pytest.importorskip("igraph")
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _copy_fixture(tmp_path: Path) -> Path:
+    """Copy the Leavenworth CSV fixture into ``tmp_path`` so tests can mutate it freely."""
+    dest = tmp_path / "leavenworth_csv"
+    shutil.copytree(leavenworth.csv_dir(), dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# clean — remove-orphans + dry-run + dest
+# ---------------------------------------------------------------------------
+
+
+def test_clean_simplify_dry_run_does_not_write(tmp_path: Path):
+    """``--dry-run`` rolls back before write — the source on disk stays unchanged."""
+    src = _copy_fixture(tmp_path)
+    link_csv = src / "link.csv"
+    before_bytes = link_csv.read_bytes()
+    result = runner.invoke(
+        app,
+        [
+            "clean",
+            "remove-orphans",  # use a no-geometry op; simplify needs a geometry column
+            "--json",
+            "--dry-run",
+            "--engine",
+            "pandas",
+            str(src),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    # File on disk must be untouched — dry-run never writes.
+    assert link_csv.read_bytes() == before_bytes
+
+
+def test_clean_simplify_writes_to_dest(tmp_path: Path):
+    """``--dest <dir>`` writes the modified package there and leaves the source alone."""
+    src = _copy_fixture(tmp_path)
+    dest = tmp_path / "cleaned"
+    src_link_before = (src / "link.csv").read_bytes()
+    result = runner.invoke(
+        app,
+        [
+            "clean",
+            "remove-orphans",
+            "--json",
+            "--dest",
+            str(dest),
+            "--engine",
+            "pandas",
+            str(src),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    # Source untouched.
+    assert (src / "link.csv").read_bytes() == src_link_before
+    # Dest exists and is loadable as a package.
+    assert dest.exists()
+    # Round-trip through the loader to confirm the on-disk package is valid.
+    from datagrove.engines.pandas_engine import PandasEngine
+    from gmnspy import Network
+
+    net = Network.from_source(dest, engine=PandasEngine())
+    assert net.links.count() > 0
+    assert net.nodes.count() > 0
+
+
+def test_clean_remove_orphans_json_emits_summary(tmp_path: Path):
+    """``--json`` payload carries the standard {op, dry_run, edits[]} summary."""
+    src = _copy_fixture(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "clean",
+            "remove-orphans",
+            "--json",
+            "--dry-run",
+            "--engine",
+            "pandas",
+            str(src),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["op"] == "remove_orphans"
+    assert payload["dry_run"] is True
+    assert isinstance(payload["edits"], list) and payload["edits"]
+    assert payload["edits"][0]["table"] == "node"
+    assert payload["edits"][0]["op"] == "replace_table"
+
+
+# ---------------------------------------------------------------------------
+# scope — from-nodes / connected-component / from-zone
+# ---------------------------------------------------------------------------
+
+
+def test_scope_from_nodes_json_emits_sets():
+    """``scope from-nodes --json`` returns {node_count, link_count, node_ids, link_ids}."""
+    result = runner.invoke(
+        app,
+        ["scope", "from-nodes", "--json", "--no-path-between", str(leavenworth.csv_dir()), "1", "2"],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    # The two seeds + induced links between them must be present.
+    assert 1 in payload["node_ids"]
+    assert 2 in payload["node_ids"]
+    assert payload["node_count"] == len(payload["node_ids"])
+    assert payload["link_count"] == len(payload["link_ids"])
+    assert "from_nodes" in payload["provenance"]
+
+
+def test_scope_connected_component_json():
+    """``scope connected-component`` returns a non-empty single-component result."""
+    result = runner.invoke(
+        app,
+        ["scope", "connected-component", "--json", str(leavenworth.csv_dir()), "1"],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["node_count"] >= 1
+    assert 1 in payload["node_ids"]
+    assert "connected_component" in payload["provenance"]
+
+
+def test_scope_from_zone_json():
+    """``scope from-zone`` works on a fixture with a zone_id column.
+
+    The bundled Leavenworth fixture has no ``zone_id`` column, so we
+    expect a typed error (exit 1) rather than a silent empty scope —
+    that's the contract documented on :func:`gmnspy.scope.from_zone`.
+    """
+    result = runner.invoke(
+        app,
+        ["scope", "from-zone", "--json", str(leavenworth.csv_dir()), "100"],
+    )
+    # No zone_id column → ScopeError → CLI exits 1 with a clean message.
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# index — build / status / drop
+# ---------------------------------------------------------------------------
+
+
+def test_index_build_json_creates_cache_files(tmp_path: Path):
+    """``index build --json`` returns parquet paths and the files exist on disk.
+
+    The Leavenworth fixture has no inline link geometry, so spatial is
+    auto-skipped; the graph index is built and cached.
+    """
+    src = _copy_fixture(tmp_path)
+    result = runner.invoke(app, ["index", "build", "--json", str(src)])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["graph"] is True
+    # Spatial silently skipped because the fixture lacks a geometry column.
+    assert payload["spatial"] is False
+    assert payload["skipped_spatial_no_geometry"] is True
+    assert payload["paths"]
+    for p in payload["paths"]:
+        assert Path(p).is_file(), f"expected sidecar {p} on disk"
+
+
+def test_index_status_finds_built_indexes(tmp_path: Path):
+    """After ``build``, ``status`` reports the sidecars as present."""
+    src = _copy_fixture(tmp_path)
+    build_res = runner.invoke(app, ["index", "build", "--json", str(src)])
+    assert build_res.exit_code == 0, build_res.stdout
+    status_res = runner.invoke(app, ["index", "status", "--json", str(src)])
+    assert status_res.exit_code == 0, status_res.stdout
+    payload = json.loads(status_res.stdout)
+    assert payload["graph"] is True
+    assert payload["paths"]  # at least the graph sidecar
+
+
+def test_index_drop_removes_cache(tmp_path: Path):
+    """After ``drop``, ``status`` reports the sidecars as absent."""
+    src = _copy_fixture(tmp_path)
+    assert runner.invoke(app, ["index", "build", "--json", str(src)]).exit_code == 0
+    drop_res = runner.invoke(app, ["index", "drop", "--json", str(src)])
+    assert drop_res.exit_code == 0, drop_res.stdout
+    drop_payload = json.loads(drop_res.stdout)
+    assert drop_payload["count"] >= 1
+    # Status should now report nothing cached.
+    status_res = runner.invoke(app, ["index", "status", "--json", str(src)])
+    assert status_res.exit_code == 0, status_res.stdout
+    status_payload = json.loads(status_res.stdout)
+    assert status_payload["graph"] is False
+    assert status_payload["paths"] == []
+
+
+# ---------------------------------------------------------------------------
+# Help discovery — the new top-level commands must show up
+# ---------------------------------------------------------------------------
+
+
+def test_clean_subcommand_listed_in_help():
+    """``gmnspy --help`` advertises the three new sub-apps."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Strip ANSI/rich-box characters by checking for the bare token.
+    out = result.stdout
+    assert "clean" in out
+    assert "scope" in out
+    assert "index" in out


### PR DESCRIPTION
Wires three CLI sub-apps onto ``gmnspy.cli`` that wrap existing programmatic APIs. Closes #88.

## Summary

- **``gmnspy clean simplify-geometry|merge-close-nodes|remove-orphans|recompute-lengths``** — runs each op inside an editing ``Session`` for atomic rollback; ``--dry-run`` rolls back before write so the source on disk stays untouched, ``--dest`` redirects writes to a different path, ``--engine`` lets callers pick the backend. Optional-extra resolution via ``importlib`` so the ``gmnspy.cli ↛ gmnspy.clean`` import-linter contract still holds.
- **``gmnspy scope from-nodes|from-node|connected-component|from-zone``** — read-only; builds a ``NetworkScope`` from a seed and prints ``{node_count, link_count, node_ids, link_ids, provenance}``. ``ScopeError`` / ``ImportError`` surface as a clean exit 1 with a message rather than a traceback.
- **``gmnspy index build|status|drop``** — manages the sidecar parquet cache under ``<source.parent>/_gmnspy_indexes/``. ``build`` content-hashes the link (+node for graph) tables; ``status`` globs the dir; ``drop`` deletes the sidecars. Auto-skips the spatial index when no inline geometry column exists.

## Test plan

- [x] ``uv run pytest packages/gmnspy/tests/test_cli_clean_scope_index.py -v`` — 10/10 pass.
- [x] ``uv run pytest`` — 828 pass / 50 skipped (was 818 baseline; +10 new tests).
- [x] ``uv run ruff check packages/ scripts/ main.py`` — clean.
- [x] ``uv run ruff format --check packages/ scripts/ main.py`` — clean.
- [x] ``uv run lint-imports`` — both contracts still kept (``gmnspy.cli ↛ gmnspy.clean`` holds via ``importlib``).
- [x] ``uv run python scripts/lint_no_sql.py`` — clean.

## Deferred to v1.1 (per task brief)

- ``clean snap-to-reference`` / ``connect-disconnected-components`` / ``split-link-at-node`` (ops themselves deferred).
- ``scope buffer-network`` / ``buffer-spatial`` (require chaining).
- ``--auto-build-threshold`` flag (the scope ops auto-build already).

Generated with [Claude Code](https://claude.com/claude-code)