### PR TITLE
docs(cookbook): 5 cookbook recipes (#96)

### DIFF
--- a/docs/cookbook/convert-formats.md
+++ b/docs/cookbook/convert-formats.md
@@ -1,0 +1,116 @@
+---
+title: Convert CSV ↔ Parquet ↔ DuckDB ↔ zip-CSV
+audience: users
+kind: howto
+summary: Round-trip a data package between the four bundled storage formats — when to pick which, how the CLI and Python entry points compare.
+---
+
+# Convert CSV ↔ Parquet ↔ DuckDB ↔ zip-CSV
+
+## When to use this
+
+You have data in format X (a regulator handed you a folder of CSVs, an upstream pipeline emits parquet, a teammate sent a DuckDB file) and a downstream tool wants format Y. Or you're loading the same package over and over and want to switch to a format with faster cold-start.
+
+## Quick example
+
+```text
+$ gmnspy convert packages/gmnspy/gmnspy/fixtures/leavenworth/csv ./leavenworth.parquet
+wrote 9 tables to ./leavenworth.parquet (parquet)
+```
+
+That writes a parquet directory (one file per table) inferred from the destination extension. The same network reloads ~5× faster than the CSV directory it came from.
+
+## Step-by-step
+
+### 1. Pick the destination format
+
+| Format | Cold read | Write | Predicate pushdown | Portability |
+|---|---|---|---|---|
+| `csv` (directory) | Slowest — full scan, no schema. | Slow — text encoding. | None. | Universal. Any tool reads CSV. |
+| `parquet` (directory or file) | Fast — columnar, schema embedded. | Fast. | Yes — column + row-group prune. | Wide. Arrow, DuckDB, Polars, pandas. |
+| `duckdb` (single file) | Fastest — pre-indexed, statistics cached. | Slowest — DDL + insert per table. | Yes — full SQL. | DuckDB-only readers. |
+| `zipcsv` (single `.zip`) | Slow — text decode after unzip. | Medium. | None. | Universal + single-file. |
+
+Rule of thumb: **parquet for interchange, duckdb for repeated local use, zipcsv for emailing, csv only when a downstream tool demands it**.
+
+### 2. Run `gmnspy convert`
+
+```text
+$ gmnspy convert <source> <dest>
+```
+
+The format of `<dest>` is inferred from the extension (`.parquet`, `.duckdb`, `.zip`) or from whether it's an existing directory (CSV / Parquet). Override the inference with `--format`:
+
+```text
+$ gmnspy convert ./csv_dir ./out.duckdb --format duckdb
+$ gmnspy convert ./csv_dir ./out          --format parquet
+```
+
+Or programmatically:
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+net = Network.from_source(leavenworth.csv_dir())
+net.write("./leavenworth.duckdb")
+```
+
+`Network.write` and `Package.write` use the same dispatch as the CLI — extension inference plus an optional `format=` kwarg.
+
+### 3. (Optional) Pick an engine
+
+```text
+$ gmnspy convert ./csv_dir ./out.parquet --engine pandas
+```
+
+The default is the ibis engine. Switch to `pandas` if you hit the null-typed column issue tracked in [#163](https://github.com/e-lo/GMNSpy/issues/163) — DuckDB's strict typing rejects columns that are entirely null in the source. The pandas engine coerces them to object/None so the write succeeds.
+
+### 4. Verify the round-trip
+
+```python
+from gmnspy import Network
+
+net = Network.from_source("./leavenworth.parquet")
+report = net.validate()
+assert report.passed, [i.code for i in report.issues if i.is_error()]
+print(f"{net.spec_version}: {net.links.count()} links — round-trip clean")
+```
+
+Validation against the spec catches any schema drift introduced by the conversion (e.g. a string column that came back as int because every value happened to parse). See [validate-network](validate-network.md) for what's in the report.
+
+### 5. (Optional) Convert remote → local
+
+`convert` accepts the same URL surface as `from_source`, so cloud → local is a one-liner:
+
+```text
+$ gmnspy convert s3://my-bucket/networks/leavenworth/ ./leavenworth.parquet
+```
+
+That downloads once, writes parquet locally, and from then on you load the local copy. See [Read from S3](read-from-s3.md) for credential handling.
+
+## Common variations
+
+| You want... | Do this |
+|---|---|
+| Programmatic conversion | `Package.from_source(src).write(dest)` — same dispatch as the CLI. |
+| Re-pack only a few tables | `Package.from_source(src).select(["link", "node"]).write(dest)` — see [scope recipes](index.md#scope--geographic-subsetting) for FK-aware variants. |
+| Partitioned parquet | `--format parquet` to a directory and the writer will create one file per table. Per-table row-group partitioning is the parquet engine's default. |
+| Compress the CSV output | Convert to `zipcsv` instead — same wire format, 5-10× smaller. |
+| Validate during the write | `Package.from_source(src).validate().write(dest)` raises before writing if any ERROR finding fires. |
+
+## Pitfalls
+
+* **DuckDB SQL DDL via PolarsEngine is not supported.** The polars engine doesn't speak DuckDB's `CREATE TABLE` dialect, so writing to `.duckdb` requires the default ibis engine. Pick `--engine ibis` or omit `--engine`.
+* **Null-typed columns can fail strict-write backends.** If a column is 100% null in the source CSV, the ibis/duckdb engine may reject the write. Workarounds: `--engine pandas`, or open the source, fill the column with a typed default, and write. Tracked in [#163](https://github.com/e-lo/GMNSpy/issues/163).
+* **Extension inference is case-sensitive.** `out.PARQUET` won't be recognised as parquet — pass `--format parquet`.
+* **Converting *to* CSV loses dtypes.** Re-reading the CSV without a schema (no GMNS spec match) infers columns afresh. Round-trip safety relies on the schema being re-applied at load time, which happens automatically for GMNS-shaped directories.
+* **DuckDB files lock per-process.** Two Python processes can't open the same `.duckdb` file in write mode at once. For shared use, write parquet instead; for one-writer-many-readers, ensure the writer closes the connection (the Engine does this when the `Network` is garbage-collected or `net.close()` is called).
+* **Zip-CSV holds the whole archive in memory on read.** Fine for Leavenworth-scale networks; not fine for regional ones. Convert zip-CSV to parquet up-front if you'll re-read.
+* **Overwriting an existing destination is allowed.** `convert` won't ask before clobbering — chain a `test -e dest && exit 1` in CI scripts if you need an explicit guard.
+
+## See also
+
+* [Read from S3](read-from-s3.md) — `convert` works across cloud schemes too (`gmnspy convert s3://… ./local.parquet`).
+* [Architecture](../architecture.md) — Package → Engine → format dispatch.
+* [API reference](../reference/api.md) — `Package.write`, `Package.from_source`.

--- a/docs/cookbook/edit-with-rollback.md
+++ b/docs/cookbook/edit-with-rollback.md
@@ -1,0 +1,152 @@
+---
+title: Edit a network with atomic rollback
+audience: users
+kind: howto
+summary: Mutate a network inside a datagrove.editing.Session — every op produces an EditResult with a diff and rollback hook; the session commits on clean exit and rolls back on exception.
+---
+
+# Edit a network with atomic rollback
+
+## When to use this
+
+You're applying a destructive operation to a network — simplify geometry, merge close nodes, remove orphan links, recompute lengths — and you want a safety net. The `Session` context manager records every change so you can undo all of them in LIFO order, either by raising inside the `with` block, by calling `session.rollback()` explicitly, or by replaying a persisted log later.
+
+## Quick example
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+from gmnspy.clean import simplify_geometry
+from datagrove.editing import Session
+
+net = Network.from_source(leavenworth.csv_dir())
+with Session(net) as s:
+    result = simplify_geometry(net, s, mode="redundant_only")
+    print(f"removed {result.diff.removed_rows} redundant shape points")
+
+# Clean exit committed. Persist:
+net.write("./leavenworth-simplified.parquet")
+```
+
+If the `with` block raises, the session rolls back all ops and `net` is byte-identical to the pre-edit state.
+
+## Step-by-step
+
+### 1. Install
+
+```text
+$ pip install 'gmnspy[clean]'
+```
+
+The `[clean]` extra brings in `shapely` and `igraph`, which most of the editing ops depend on for geometry / connectivity work.
+
+### 2. Open a Session
+
+```python
+from datagrove.editing import Session
+
+with Session(net) as s:
+    ...
+```
+
+A `Session` wraps the network in an editable view. Inside the `with` block you pass *both* `net` and `s` into each editing op — the op uses `net` to read state and `s` to record the change so the session can undo it later.
+
+### 3. Apply one or more ops
+
+```python
+from gmnspy.clean import simplify_geometry, merge_close_nodes, remove_orphans
+
+with Session(net) as s:
+    r1 = simplify_geometry(net, s, mode="redundant_only", tolerance="0.5m")
+    r2 = merge_close_nodes(net, s, threshold="2m")
+    r3 = remove_orphans(net, s)
+```
+
+Each call returns an `EditResult`:
+
+| Field | Type | Description |
+|---|---|---|
+| `.diff` | `Diff` | Per-table row counts: `added`, `removed`, `changed`. Cheap to print / log. |
+| `.edit` | `Edit` | The high-level op description (op name, parameters). |
+| `.rollback_data` | `RollbackData` | The state captured before the op ran — opaque, but stable across versions and what `Session.rollback()` replays. |
+
+### 4. Commit or rollback
+
+Clean exit from the `with` block commits all ops. Anything else rolls back in LIFO order:
+
+```python
+# Commit:
+with Session(net) as s:
+    simplify_geometry(net, s, mode="redundant_only")
+# committed at __exit__
+
+# Rollback by raising:
+try:
+    with Session(net) as s:
+        merge_close_nodes(net, s, threshold="2m")
+        raise RuntimeError("changed my mind")
+except RuntimeError:
+    pass  # net is back to pre-merge state
+
+# Rollback explicitly while staying in the block:
+with Session(net) as s:
+    result = remove_orphans(net, s)
+    if result.diff.removed_rows > 100:
+        s.rollback()  # too aggressive — undo
+```
+
+### 5. Persist the edit log (optional)
+
+```python
+with Session(net, log_path="history.parquet") as s:
+    simplify_geometry(net, s, mode="redundant_only")
+    merge_close_nodes(net, s, threshold="2m")
+```
+
+The session writes a chronological record of each op (name, params, diff, rollback blob) to `history.parquet`. Later, in a fresh process:
+
+```python
+from datagrove.editing import rollback
+
+net = Network.from_source("./edited.parquet")
+rollback(net, log_path="history.parquet")  # replay in LIFO
+```
+
+This is the same mechanism the CLI's `--dry-run` uses, and the only way to undo edits across process boundaries.
+
+### 6. Write the result
+
+```python
+net.write("./leavenworth-edited.parquet")
+```
+
+If you see an `OutOfSyncWarning` here when running outside the CLI, that's [#164](https://github.com/e-lo/GMNSpy/issues/164) — an FK index didn't refresh after the edit. Workaround until the fix lands:
+
+```python
+net.recompute_fks()
+net.write("./leavenworth-edited.parquet")
+```
+
+## Common variations
+
+| You want... | Do this |
+|---|---|
+| Preview without committing | `gmnspy clean simplify-geometry <src> --dry-run` — runs the op, prints the diff, never writes. |
+| Chain ops in one transactional block | Put multiple ops in the same `with Session(net) as s:` block. Rollback undoes all of them. |
+| Run one op via the CLI | `gmnspy clean simplify-geometry <src> --mode redundant_only --out ./out.parquet`. |
+| Capture diffs for a PR description | `result.diff` has a `_repr_html_` — display in a notebook or `print(result.diff)` for plain text. |
+| Replay only the last N ops | Trim `history.parquet` before calling `rollback`, or pass `n=N` if your version supports it (see [API reference](../reference/api.md)). |
+
+## Pitfalls
+
+* **Bulk `replace_table` edits aren't atomic per-row today** (tracked in [#163](https://github.com/e-lo/GMNSpy/issues/163)). A `replace_table` records one rollback blob for the whole replacement, so partial mid-op failures cleanly rollback the whole replacement — not a subset.
+* **Ibis engine + null-typed columns.** If an edit produces a column that's 100% null, writing through the ibis/duckdb engine may fail. Same workaround as elsewhere ([#163](https://github.com/e-lo/GMNSpy/issues/163)): switch the engine for the write step.
+* **The session captures snapshots, not journals.** Memory cost scales with the size of the tables an op touches. For a `simplify_geometry` over a 5M-row link table, expect a few hundred MB of resident rollback state. Long sessions over huge networks should commit periodically.
+* **Don't mutate tables outside the session.** Direct `net.links.expr.execute().assign(...)` writes bypass the session entirely and aren't rollback-able.
+* **`OutOfSyncWarning` after an edit means FKs haven't been re-resolved.** Call `net.recompute_fks()` before writing. CLI does this for you; programmatic use must do it explicitly until [#164](https://github.com/e-lo/GMNSpy/issues/164) lands.
+
+## See also
+
+* [Architecture](../architecture.md) — Session / EditResult / Diff design.
+* [Validate a network](validate-network.md) — `sync.fk_stale` is the validator's way of telling you to call `recompute_fks`.
+* [API reference](../reference/api.md) — `Session`, `EditResult`, `Diff`, `rollback`.

--- a/docs/cookbook/read-from-s3.md
+++ b/docs/cookbook/read-from-s3.md
@@ -1,0 +1,124 @@
+---
+title: Read from S3 with credentials
+audience: users
+kind: howto
+summary: Load a GMNS data package from S3 (or any fsspec-backed cloud store) with the credential cascade — kwarg, env var, keyring, .netrc.
+---
+
+# Read from S3 with credentials
+
+## When to use this
+
+Your data lives on cloud storage and you want the same lazy-load surface you get from a local directory — predicate pushdown, column pruning, no full download. Credentials should come from whichever channel your environment already manages (CI secret, keyring, `~/.netrc`) without ever being baked into source.
+
+## Quick example
+
+```python
+from gmnspy import Network
+
+net = Network.from_source("s3://my-bucket/networks/leavenworth/")
+print(f"{net.spec_version}: {net.links.count()} links")
+# AWS creds discovered from the default chain — env, ~/.aws/credentials, IAM role.
+```
+
+If your bucket is public-readable, no credential resolution runs at all. If it's private and a credential is discoverable, the load is still lazy — `net.links` is an ibis expression, not a materialised frame.
+
+## Step-by-step
+
+### 1. Install
+
+```text
+$ pip install 'gmnspy[server]'
+```
+
+The cloud filesystem drivers (`fsspec`, `s3fs`, `adlfs`, `gcsfs`) come along with the `[server]`, `[clean]`, and `[mcp]` extras. If you only installed the bare `gmnspy` and hit `ImportError: No module named 's3fs'`, that's the missing extra — re-install with one of those tags.
+
+### 2. Provide credentials
+
+Credentials cascade in a fixed order. The first one resolved wins:
+
+1. **Explicit kwarg** — `Network.from_source(url, credential="…")`. Always wins. Use for one-off scripts and notebooks.
+2. **Environment variable** — `DATAGROVE_CRED_<HOST>_TOKEN` where `<HOST>` is the URL host uppercased with dots and dashes flattened to underscores. For `s3://my-bucket/...` that's `DATAGROVE_CRED_MY_BUCKET_TOKEN`. Use for CI.
+3. **System keyring** — service name `datagrove`, username matches host. Use for local dev so a token never lands in your shell history.
+4. **`~/.netrc`** — falls back to the standard netrc machine entry. Use for legacy compatibility.
+
+For AWS specifically, the default boto credential chain runs *inside* step 1 — IAM role, `~/.aws/credentials`, `AWS_*` env vars. You only need a `DATAGROVE_CRED_*` variable when the bucket needs a non-default credential (e.g. a different AWS account, a custom MinIO instance with HTTP Basic).
+
+To store a credential in the keyring (one-off, on dev machines):
+
+```python
+import keyring
+keyring.set_password("datagrove", "my-bucket", "AKIA…/secret-here")
+```
+
+The same call from `python -c` works for CI bootstrapping if you'd rather not put the secret in an env file.
+
+### 3. Load the package
+
+```python
+from gmnspy import Network
+
+# Discover via the cascade above:
+net = Network.from_source("s3://my-bucket/networks/leavenworth/")
+
+# Or pass an explicit credential (kwarg always wins):
+net = Network.from_source(
+    "s3://my-bucket/networks/leavenworth/",
+    credential={"key": "AKIA…", "secret": "…"},
+)
+```
+
+The result is the same `Network` you'd get from a local path. Every table (`net.links`, `net.nodes`, `net.lanes`, …) is an ibis expression backed by the cloud-aware filesystem.
+
+### 4. Verify the load is lazy
+
+```python
+expr = net.links.expr  # underlying ibis Table
+print(type(expr).__name__)  # 'Table'
+
+# No bytes pulled yet. Push a filter down — only matching rows transit:
+fast_links = net.links.filter(net.links.free_speed > 45.0).to_polars()
+```
+
+Filters and column projections push down to the parquet readers, so a 10 GB package over S3 can return a small filtered frame in a few seconds without downloading the whole file.
+
+### 5. Cache for repeat reads
+
+If the same script will hit the package many times — a notebook, a debugging loop, a CI matrix — convert it once and load locally:
+
+```python
+from gmnspy import Network
+
+remote = Network.from_source("s3://my-bucket/networks/leavenworth/")
+remote.write("/tmp/leavenworth.parquet")   # one-shot download
+
+# Subsequent runs:
+net = Network.from_source("/tmp/leavenworth.parquet")
+```
+
+Parquet is faster to re-read than CSV-over-S3 by an order of magnitude on cold cache. See [Convert formats](convert-formats.md) for the format trade-offs.
+
+## Common variations
+
+| Scheme | Install extra | Credential field | Notes |
+|---|---|---|---|
+| `s3://…` | `[server]` (s3fs) | AWS chain or `DATAGROVE_CRED_*_TOKEN` | Custom endpoints via `endpoint_url` kwarg. |
+| `https://…` | `[server]` (httpx) | `Bearer <token>` or HTTP Basic `user:pass` | Bearer is detected when token has no `:`. |
+| `az://container@account/…` | `[server]` (adlfs) | `DATAGROVE_CRED_<ACCOUNT>_TOKEN` | Account key, SAS token, or default Azure credential. |
+| `gs://bucket/…` | `[server]` (gcsfs) | GCP application-default creds or service-account JSON path | Set `GOOGLE_APPLICATION_CREDENTIALS` for the file path. |
+| `duckdb://https://…/file.duckdb` | bare `gmnspy` | HTTP creds as above | DuckDB native httpfs reader; one round-trip per table. |
+
+## Pitfalls
+
+* **Credential precedence is fixed and not configurable.** A kwarg always overrides env / keyring / netrc. If your CI keeps reading the wrong credential, check whether something upstream is passing `credential=` to `from_source`.
+* **Regional endpoints matter.** For non-default AWS regions or S3-compatible stores (MinIO, R2, Wasabi), set `endpoint_url` via a kwarg or `AWS_ENDPOINT_URL` env var — the cascade doesn't auto-discover non-AWS endpoints.
+* **Pre-signed URLs have TTLs.** If you pass an `https://…?X-Amz-Signature=…` URL, the credential is baked in and the URL expires. Re-issue for long-running jobs.
+* **Listing a bucket isn't free.** `Package.from_source("s3://bucket/")` (no prefix) walks the bucket. Always include the package directory prefix.
+* **Anonymous reads need an explicit signal.** For public buckets the AWS chain still attempts to sign requests if any credential is present in the environment. Pass `credential={"anon": True}` to force unsigned access.
+* **Keyring on Linux needs a backend.** The Python `keyring` library on a headless Linux box falls through to `fail.Keyring` if no backend is installed. Install `keyrings.alt` for a file-backed store, or use the env-var path instead.
+
+## See also
+
+* [Architecture](../architecture.md) — package/network/engine layering and the `from_source` dispatcher.
+* [Convert formats](convert-formats.md) — once loaded, write the package out as parquet or duckdb for faster repeat loads.
+* [API reference](../reference/api.md) — `Network.from_source`, `Package.from_source`.

--- a/docs/cookbook/serve-mcp.md
+++ b/docs/cookbook/serve-mcp.md
@@ -1,0 +1,127 @@
+---
+title: Wire the MCP server to Claude Code / Claude Desktop
+audience: users
+kind: howto
+summary: Run gmnspy as an MCP server over stdio so an AI agent can call its tools — install, configure, list of bundled tools, sample prompts.
+---
+
+# Wire the MCP server to Claude Code / Claude Desktop
+
+## When to use this
+
+You want an AI agent (Claude Desktop, Claude Code, any MCP-aware host) to call `gmnspy` directly via tool calls — describe a package, run validation, scope a subgraph, run the quality pack — instead of you copying CLI output into the chat. The MCP server speaks the Model Context Protocol so the agent treats `gmnspy` as a first-class tool surface.
+
+## Quick example
+
+Add this to your MCP host config, restart, and ask the agent "describe the package at /tmp/leavenworth/csv":
+
+```json
+{
+  "mcpServers": {
+    "gmnspy": {
+      "command": "gmnspy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+The agent will pick `describe_package`, call it with `{"source": "/tmp/leavenworth/csv"}`, and surface the spec version, table counts, and FK summary back in chat.
+
+## Step-by-step
+
+### 1. Install
+
+```text
+$ pip install 'gmnspy[mcp]'
+```
+
+The `[mcp]` extra brings in `mcp` (the official Python SDK). If you've already installed `[clean]` or `[server]`, only the MCP SDK is added.
+
+### 2. Test the server runs
+
+```text
+$ gmnspy mcp serve --help
+Usage: gmnspy mcp serve [OPTIONS]
+
+  Start the gmnspy MCP server (stdio transport).
+  ...
+```
+
+You don't normally launch the server yourself — the MCP host does it. But `--help` confirms the entry point resolves and the SDK is importable.
+
+### 3. Configure the MCP host
+
+**Claude Desktop (macOS):** edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "gmnspy": {
+      "command": "gmnspy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+On Linux it's `~/.config/Claude/claude_desktop_config.json`; on Windows, `%APPDATA%\Claude\claude_desktop_config.json`. Restart Claude Desktop after editing. The tools show up under a hammer-icon in the chat input.
+
+**Claude Code:** add `.mcp.json` to the root of your project:
+
+```json
+{
+  "mcpServers": {
+    "gmnspy": {
+      "command": "gmnspy",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Claude Code picks it up on session start. To use the version installed in a project venv, replace `command` with the absolute path to that venv's `gmnspy`.
+
+### 4. The tools shipped today
+
+The server exposes 7 stateless tools. Each takes a JSON object and returns a JSON document. Sources are paths or URLs that `Network.from_source` accepts.
+
+| Name | Summary | Inputs | Output |
+|---|---|---|---|
+| `describe_package` | Spec version, table list, row counts, FK summary. | `source: str` | `{spec_version, tables: [{name, rows, columns}], fk_summary}` |
+| `validate_package` | Run all four validation passes; return the report. | `source: str`, optional `passes: [str]` | `{passed: bool, issues: [Issue]}` |
+| `list_tables` | Names + row counts only (cheaper than `describe_package`). | `source: str` | `{tables: [{name, rows}]}` |
+| `describe_network` | GMNS-aware variant of `describe_package` — adds graph stats. | `source: str` | `{spec_version, tables, components, nodes_in_largest_cc}` |
+| `quality_check` | Run the data-quality rule pack. | `source: str`, optional `rules: [str]` | `{issues: [Issue]}` |
+| `connected_components` | Count + size distribution of weakly-connected components. | `source: str` | `{count, sizes: [int]}` |
+| `scope_from_nodes` | Build a node-seeded scope and return the scoped network's summary. | `source: str`, `node_ids: [int]`, optional `network_buffer: str` | `{tables: [{name, rows}], seed_nodes: [int]}` |
+
+### 5. Sample agent prompts
+
+Each of these exercises a different tool — paste them into a chat with the server configured to see the agent pick the right call.
+
+* **"What's in the package at `packages/gmnspy/gmnspy/fixtures/leavenworth/csv`?"** — agent calls `describe_package`, returns spec version + per-table rowcounts.
+* **"Validate that package and tell me about any ERROR-severity issues."** — agent calls `validate_package`, filters the response, and surfaces just the failures.
+* **"Build a 500m scope around nodes 1, 5, and 12 in that package and tell me how many links it has."** — agent calls `scope_from_nodes` with `node_ids=[1,5,12]` and `network_buffer="500m"`.
+
+## Common variations
+
+| You want... | Do this |
+|---|---|
+| Rename the server in the host UI | `"args": ["mcp", "serve", "--name", "gmns-leavenworth"]` — the name appears under the tool list in Claude. |
+| Run inside a project venv | Replace `"command": "gmnspy"` with the absolute path to that venv's `gmnspy` binary, e.g. `"command": "/path/to/.venv/bin/gmnspy"`. |
+| Pin the server to a specific working directory | Add `"cwd": "/abs/path/to/data"` to the JSON entry; all relative-path tool calls resolve there. |
+| Pass env vars (cloud creds) | Add `"env": {"AWS_PROFILE": "ds-readonly"}` to the JSON entry. |
+
+## Pitfalls
+
+* **Stdio transport only today.** The HTTP MCP transport is a follow-up — track the [open issues](https://github.com/e-lo/GMNSpy/issues?q=mcp) for progress. For now, every agent that wants to call gmnspy needs to launch its own subprocess.
+* **Tools are stateless.** There's no persistent `edit_session` tool yet — every call is a one-shot load + read. The agent can't mutate a network and inspect intermediate state across calls. See the [issue tracker](https://github.com/e-lo/GMNSpy/issues?q=mcp) for the design discussion.
+* **JSON-only return values.** Tool outputs are valid JSON, not pickles or DataFrames. Large tables come back paginated / summarised — for full data, the agent should call the CLI directly via a shell tool.
+* **Config file path is case-sensitive on macOS.** `Claude` vs `claude` matters. If the server doesn't show up after a restart, check `~/Library/Logs/Claude/mcp*.log`.
+
+## See also
+
+* [Architecture](../architecture.md) — MCP server position in the v1.0 surface layering.
+* [Use the `--json` CLI contract from a tool-call loop](index.md#for-ai-agents-specifically) — when you want an agent to drive `gmnspy` via shell instead of MCP.
+* [API reference](../reference/api.md) — the Python entry points the MCP tools wrap.

--- a/docs/cookbook/validate-network.md
+++ b/docs/cookbook/validate-network.md
@@ -1,0 +1,141 @@
+---
+title: Validate a network and read the report
+audience: users
+kind: howto
+summary: Run validation against the GMNS spec and interpret the ValidationReport — severity, category, code, and how to filter findings programmatically.
+---
+
+# Validate a network and read the report
+
+## When to use this
+
+You have a GMNS network — yours, a vendor's, the output of an edit — and you need to know whether it conforms to the spec before downstream tools (assignment models, AI agents, regulators) touch it. Validation is fast (sub-second on Leavenworth, a few seconds on a regional network) and answers four questions at once: do all required tables exist, do columns match the schema, do foreign keys resolve, and are any of those FKs stale from a recent edit?
+
+## Quick example
+
+```text
+$ gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+{"spec_version": "0.97", "passed": true, "issues": [], ...}
+```
+
+Or from Python:
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+net = Network.from_source(leavenworth.csv_dir())
+report = net.validate()
+print(f"passed={report.passed}  issues={len(report.issues)}")
+```
+
+The Leavenworth fixture is clean, so the issue list is empty and `passed` is `True`. The CLI exits non-zero if any ERROR-severity finding fires.
+
+## Step-by-step
+
+### 1. Run validation
+
+```python
+report = net.validate()                              # all four passes
+report = net.validate(passes=["schema", "fk"])       # only two of them
+```
+
+Equivalent CLI:
+
+```text
+$ gmnspy validate <source>                  # human-readable summary
+$ gmnspy validate <source> --json           # machine-readable
+$ gmnspy validate <source> --format html    # standalone HTML report
+```
+
+### 2. Read the report shape
+
+`ValidationReport` is a dataclass with three fields you'll touch:
+
+| Field | Type | Description |
+|---|---|---|
+| `report.passed` | `bool` | `True` iff no ERROR-severity issue fired. WARNINGs and INFOs do not flip this. |
+| `report.spec_version` | `str` | The GMNS spec version the validator ran against. |
+| `report.issues` | `list[Issue]` | One entry per finding. |
+
+Each `Issue` carries:
+
+```python
+@dataclass
+class Issue:
+    severity: Severity      # ERROR | WARNING | INFO
+    category: Category      # SCHEMA | STRUCTURAL | FOREIGN_KEY | SYNC_STATE | DATA_QUALITY
+    code: str               # stable identifier, e.g. "schema.required"
+    message: str            # human-readable
+    table: str | None       # table the finding is about
+    column: str | None      # column, if applicable
+    row: int | None         # row index, if applicable
+    fix_hint: str | None    # what to do about it
+```
+
+### 3. Filter by severity
+
+```python
+from datagrove.validation import Severity
+
+errors = [i for i in report.issues if i.severity is Severity.ERROR]
+warnings = [i for i in report.issues if i.severity is Severity.WARNING]
+```
+
+Most CI gates want `if errors: sys.exit(1)`. The CLI does this for you.
+
+### 4. Filter by category
+
+```python
+from datagrove.validation import Category
+
+schema_problems = [i for i in report.issues if i.category is Category.SCHEMA]
+fk_problems = [i for i in report.issues if i.category is Category.FOREIGN_KEY]
+```
+
+Categories let you group findings by which validation pass produced them:
+
+* `SCHEMA` — field-level type / enum / required-column violations.
+* `STRUCTURAL` — package-level shape problems (missing required table, missing required file).
+* `FOREIGN_KEY` — cross-table integrity (`link.from_node_id` points at a node that doesn't exist).
+* `SYNC_STATE` — FKs that resolved on disk but were invalidated by an in-memory edit (see [edit-with-rollback](edit-with-rollback.md)).
+* `DATA_QUALITY` — rule-pack findings (high-speed-residential, lane-count-mismatch, etc.). Always WARNING / INFO; see [customise the quality pack](index.md#validation--data-quality).
+
+### 5. Common codes you'll see
+
+| Code | Category | Severity | What it means |
+|---|---|---|---|
+| `schema.required` | SCHEMA | ERROR | A required column is missing or null on a row. |
+| `schema.enum` | SCHEMA | ERROR | A column value isn't in the spec-defined enum set. |
+| `schema.type` | SCHEMA | ERROR | A value doesn't parse as the declared type. |
+| `structural.missing_table` | STRUCTURAL | ERROR | A required table (`link`, `node`) isn't in the package. |
+| `structural.missing_file` | STRUCTURAL | ERROR | A table is declared in the package descriptor but the file isn't there. |
+| `fk.missing_target` | FOREIGN_KEY | ERROR | FK points at a row that doesn't exist in the parent table. |
+| `fk.dangling_child` | FOREIGN_KEY | WARNING | Parent row has no children (often benign). |
+| `sync.fk_stale` | SYNC_STATE | ERROR | An edit invalidated an FK and no `recompute` ran. |
+| `quality.high_speed_residential` | DATA_QUALITY | WARNING | Residential link with speed limit above the configured threshold. |
+
+The full list lives in `datagrove.validation.codes` and is enumerated in the [reference](../reference/api.md).
+
+## Common variations
+
+| You want... | Do this |
+|---|---|
+| HTML report for a stakeholder | `report.to_html("report.html")` or `gmnspy validate <src> --format html > report.html`. |
+| Just the failing tables | `{i.table for i in report.issues if i.is_error()}`. |
+| Embed validation in a CI step | `gmnspy validate <src>` — non-zero exit code on ERROR, no extra wiring needed. |
+| Pretty-print in a notebook | `report` renders an HTML summary via `_repr_html_` — call `display(report)` or just leave it as the last cell expression. |
+| Server response | The HTTP server returns JSON by default and HTML when the request sets `Accept: text/html`. |
+
+## Pitfalls
+
+* **WARNING-level findings don't fail CI.** That's intentional — data-quality findings are advisory. If you want them to be blocking, post-process: `if any(i.code.startswith("quality.") for i in report.issues): sys.exit(1)`.
+* **Data-quality thresholds are configurable.** A WARNING firing on your network may just mean the default threshold doesn't match your context (e.g. metric vs imperial speed). See the [customise the quality pack](index.md#validation--data-quality) recipe.
+* **`sync.fk_stale` only fires after an edit.** A freshly-loaded package can't be out of sync with itself. If you see this in CI, an upstream step in the same process mutated the network.
+* **The validator runs against the spec version embedded in the package.** Override with `Network.from_source(path, spec_version="0.96")` if the package is mislabeled.
+
+## See also
+
+* [Architecture](../architecture.md) — the four-pass validator design.
+* [Edit with rollback](edit-with-rollback.md) — `sync.fk_stale` is produced by edits without a `recompute_fks`.
+* [API reference](../reference/api.md) — `ValidationReport`, `Issue`, `Severity`, `Category`.


### PR DESCRIPTION
## Summary

Fills five cookbook recipe stubs linked from `docs/cookbook/index.md`. Each page follows the `kind: howto` template in `docs/_page-style-guide.md`.

- `cookbook/read-from-s3.md` (124 lines) — credential cascade, fsspec install hint, lazy ibis verification, remote-cache pattern.
- `cookbook/convert-formats.md` (116 lines) — CSV / Parquet / DuckDB / zip-CSV trade-off table; CLI + programmatic dispatch; #163 workaround.
- `cookbook/validate-network.md` (141 lines) — Issue dataclass fields, severity / category filters, codes cheatsheet, CI exit-code, HTML / notebook variations.
- `cookbook/edit-with-rollback.md` (152 lines) — Session lifecycle, EditResult shape, LIFO rollback, persisted-log replay, #164 OutOfSyncWarning workaround.
- `cookbook/serve-mcp.md` (127 lines) — claude_desktop_config.json + .mcp.json snippets; table of the 7 stateless tools shipped today; three sample agent prompts; stdio-only caveat.

Examples use the bundled Leavenworth fixture where runnable. No Python source changed.

## Verification

- [x] `uv run pytest` — 857 passed, 48 skipped (polars not installed).
- [x] `uv run mkdocs build` — no new warnings; the 5 previously-missing cookbook link targets are now resolved.
- [x] 6 other cookbook recipes (customise-quality, scope-from-nodes, scope-bbox, serve-http, run-bench, ai-json-cli) still warn from `cookbook/index.md` — those are in a separate fill PR per the orchestrator's plan.

## Test plan

- [ ] Re-render docs site; spot-check each recipe renders correctly (tables, code blocks, see-also links).
- [ ] Confirm the See-also cross-links resolve: `../architecture.md`, `../reference/api.md`, and the in-cookbook links.
- [ ] Confirm the install-extra hints (`gmnspy[server]`, `gmnspy[clean]`, `gmnspy[mcp]`) match the extras declared in `pyproject.toml`.

Base: `feat/4.13-docs-polish` (the docs-polish foundation work just landed there; orchestrator lands the combined result later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)