### PR TITLE
docs(cookbook): 6 recipes + MCP tools reference (#96)

### DIFF
--- a/docs/ai/mcp-tools.md
+++ b/docs/ai/mcp-tools.md
@@ -1,0 +1,247 @@
+---
+title: MCP tools reference
+audience: both
+kind: reference
+summary: Complete reference for the seven MCP tools the gmnspy server exposes — four generic datagrove tools plus three GMNS-aware ones.
+---
+
+# MCP tools reference
+
+## Summary
+
+`gmnspy mcp serve` runs a stdio MCP server that exposes seven tools: four generic Frictionless-package tools inherited from `datagrove.mcp`, plus three GMNS-aware tools. Every tool is **stateless** — each call takes a `source` (path or URL) and loads the package fresh. No session, no cache, no cross-call mutation. The deferred-tools issue tracks the stateful surface (editing sessions, indexed scope ops).
+
+All tools return JSON-shaped dicts (or lists of strings); shapes are stable inside a major version. For wiring the server into Claude Desktop or Claude Code, see [Wire the MCP server](../cookbook/serve-mcp.md).
+
+## Tools
+
+### `describe_package(source)`
+
+Generic package overview. Available on any Frictionless package, not just GMNS.
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Filesystem path or URL to a package directory / `datapackage.json` |
+
+**Returns** — `dict`:
+
+```json
+{
+  "source": "<echoed input>",
+  "name": "<package name from spec>",
+  "engine": "DuckDBIbisEngine",
+  "table_count": 9,
+  "tables": [
+    {"name": "link", "rows": 214, "columns": ["link_id", "from_node_id", ...]},
+    {"name": "node", "rows": 75,  "columns": ["node_id", "x_coord", ...]}
+  ]
+}
+```
+
+`rows` / `columns` may be `null` for an individual table if its count fails (e.g. unreadable file).
+
+**Example**
+
+```json
+{"name": "describe_package", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"}}
+```
+
+### `validate_package(source)`
+
+Run the full validation pipeline (structural + schema + foreign-key + sync-state) and return the report.
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Path or URL to the package |
+
+**Returns** — `dict`:
+
+```json
+{
+  "issues": [
+    {
+      "severity": "error | warning | info",
+      "category": "structural | schema | fk | sync | data_quality",
+      "code": "fk.missing_target",
+      "message": "...",
+      "table": "lane",
+      "column": "link_id",
+      "row": 42,
+      "fix_hint": "..."
+    }
+  ],
+  "spec_version": "0.97"
+}
+```
+
+An empty `issues` list means the package is fully valid.
+
+**Example**
+
+```json
+{"name": "validate_package", "arguments": {"source": "s3://my-bucket/regional/datapackage.json"}}
+```
+
+### `list_tables(source)`
+
+Cheap variant of `describe_package` — returns just the sorted list of table names with no row counts. Useful as a first call when the agent doesn't know what's in a package.
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Path or URL |
+
+**Returns** — `list[str]`:
+
+```json
+["lane", "link", "link_tod", "node", "signal_phase", "signal_phase_mvmt", "signal_timing_plan", "use_definition", "zone"]
+```
+
+**Example**
+
+```json
+{"name": "list_tables", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"}}
+```
+
+### `describe_network(source)`
+
+GMNS-aware version of `describe_package`. Surfaces the GMNS-specific fields an agent typically wants up front (spec version, link/node counts) without iterating tables.
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Path or URL to a GMNS network |
+
+**Returns** — `dict`:
+
+```json
+{
+  "source": "<echoed input>",
+  "name": "leavenworth",
+  "spec_version": "0.97",
+  "engine": "DuckDBIbisEngine",
+  "links": 214,
+  "nodes": 75,
+  "table_count": 9,
+  "tables": ["lane", "link", "link_tod", "node", "signal_phase", ...]
+}
+```
+
+`links` / `nodes` may be `null` if the network doesn't have those tables or the count fails.
+
+**Example**
+
+```json
+{"name": "describe_network", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"}}
+```
+
+### `quality_check(source)`
+
+Run the GMNS data-quality rule pack (high-speed-residential, duplicate-near-nodes, sharp-angle bends, etc.).
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Path or URL to a GMNS network |
+
+**Returns** — same `ValidationReport` shape as `validate_package`:
+
+```json
+{
+  "issues": [
+    {
+      "severity": "warning",
+      "category": "data_quality",
+      "code": "quality.high_speed_residential",
+      "message": "link 42: speed_limit=45 > 35 mph on residential",
+      "table": "link",
+      "row": 42,
+      "fix_hint": "verify speed limit or reclassify"
+    }
+  ],
+  "spec_version": "0.97"
+}
+```
+
+Default-pack issues are WARNING / INFO — the GMNS spec is silent on these checks, but they catch common data-quality misses. Customise thresholds via the Python API ([Customise the data-quality rule pack](../cookbook/customise-quality.md)).
+
+**Example**
+
+```json
+{"name": "quality_check", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"}}
+```
+
+### `connected_components(source)`
+
+Count weakly-connected components in the network graph. Requires the `[clean]` extra (igraph) on the server side.
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `source` | string | Path or URL to a GMNS network |
+
+**Returns** — `dict`:
+
+```json
+{
+  "source": "<echoed input>",
+  "component_count": 1,
+  "sizes": [75]
+}
+```
+
+`component_count == 1` means the network is fully connected. `sizes` is the descending list of node counts per component — `[75]` for a fully-connected 75-node network; `[60, 12, 3]` for a three-component network with the largest having 60 nodes.
+
+**Example**
+
+```json
+{"name": "connected_components", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv"}}
+```
+
+### `scope_from_nodes(source, node_ids, path_between)`
+
+Build a network-aware scope from a list of seed node ids and return the resulting node + link sets.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `source` | string | — | Path or URL to a GMNS network |
+| `node_ids` | list[int] | — | Seed node ids |
+| `path_between` | bool | `true` | If true, includes all nodes/links on shortest paths between every pair of seeds. If false, keeps only the seeds + their incident links. |
+
+**Returns** — `dict`:
+
+```json
+{
+  "source": "<echoed input>",
+  "seed_node_ids": [1, 25, 50],
+  "path_between": true,
+  "result_node_count": 18,
+  "result_link_count": 31,
+  "node_ids": [1, 5, 8, 14, 25, ...],
+  "link_ids": [101, 102, 105, ...]
+}
+```
+
+The returned ids are sorted. For chaining (union / intersect / buffer), drop into the Python API — the MCP surface only exposes the leaf operation.
+
+**Example**
+
+```json
+{"name": "scope_from_nodes", "arguments": {"source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv", "node_ids": [1, 25, 50], "path_between": true}}
+```
+
+## See also
+
+* [Wire the MCP server to Claude Code / Claude Desktop](../cookbook/serve-mcp.md) — host configuration + transport details.
+* [AI surface](index.md) — how MCP fits with `llms.txt`, `api-index.json`, and the Claude Code Skills.
+* [API reference](../reference/api.md) — the underlying Python symbols each tool wraps.

--- a/docs/cookbook/ai-json-cli.md
+++ b/docs/cookbook/ai-json-cli.md
@@ -1,0 +1,117 @@
+---
+title: Drive the CLI from an AI agent loop
+audience: users
+kind: howto
+summary: Every gmnspy command emits one parseable JSON document on stdout — wire it into a tool-call loop with --json and DATAGROVE_AUTO_APPROVE.
+---
+
+# Drive the CLI from an AI agent loop
+
+## When to use this
+
+You're building an agent loop (Claude Code, a LangChain tool, a one-off shell harness) that needs to call `gmnspy` and parse the result. You don't want to spin up MCP for a stateless one-shot call.
+
+## Quick example
+
+```python
+import json, subprocess
+
+def validate(source: str) -> dict:
+    """Tool function an LLM agent can call."""
+    result = subprocess.run(
+        ["gmnspy", "validate", "--json", source],
+        capture_output=True, text=True, check=False,
+    )
+    report = json.loads(result.stdout)
+    return {
+        "ok": result.returncode == 0,
+        "error_count": sum(1 for i in report["issues"] if i["severity"] == "error"),
+        "spec_version": report["spec_version"],
+        "issues": report["issues"][:5],   # cap context cost
+    }
+
+print(validate("packages/gmnspy/gmnspy/fixtures/leavenworth/csv"))
+```
+
+## Step-by-step
+
+### 1. Every command supports `--json`
+
+```text
+$ gmnspy info     --json <source>
+$ gmnspy validate --json <source>
+$ gmnspy quality  --json <source>
+$ gmnspy scope from-nodes --json <source> 1 25 50
+$ gmnspy clean    --json <source>
+$ gmnspy bench    --json <source>
+```
+
+The `--json` contract: exactly one parseable JSON document on stdout, no log prefix, no progress bars, no trailing whitespace. `json.loads(proc.stdout)` always works on a successful run.
+
+### 2. Stderr stays separate
+
+Rich output (panels, tables, progress, approval prompts) goes to stderr. With `--json` on stdout the parser stays clean even when an approval prompt fires on stderr — the agent loop can either suppress stderr or surface it as side-channel feedback.
+
+```python
+result = subprocess.run(
+    ["gmnspy", "validate", "--json", source],
+    capture_output=True, text=True,
+)
+data = json.loads(result.stdout)        # always parseable
+diagnostics = result.stderr             # human-readable, optional to display
+```
+
+### 3. Pre-approve gated operations
+
+Mutating commands (`clean`, edit sessions) prompt for confirmation by default. In an agent loop, set the env var once instead of repeating `--yes` per call:
+
+```python
+import os, subprocess
+env = {**os.environ, "DATAGROVE_AUTO_APPROVE": "1"}
+subprocess.run(["gmnspy", "clean", "--json", source], env=env, check=False)
+```
+
+`--yes` on the command line works too. The env var is preferable for agents because it scopes to the process tree and survives `subprocess` calls from inside the loop.
+
+### 4. Schema stability
+
+The JSON shapes are stable inside a major version. Three types your loop is most likely to parse:
+
+| Type | Shape (abridged) | Returned by |
+|---|---|---|
+| `ValidationReport` | `{issues: [{severity, category, code, message, table, column, row, fix_hint}], spec_version}` | `validate`, `quality` |
+| `EditResult` | `{success, table, rows_changed, history_entry_id, dry_run, issues}` | `clean`, edit ops |
+| Command summary | per-command `{source, ...}` dict, documented in API ref | `info`, `bench`, `scope` |
+
+Full details: [API reference](../reference/api.md).
+
+### 5. Exit codes
+
+| Command | Exit 0 | Exit 1 | Exit 2 |
+|---|---|---|---|
+| `validate` | no ERROR-severity issues | ≥1 ERROR issue | CLI usage error |
+| `quality` | always (issues are WARNING/INFO) | — | CLI usage error |
+| `clean` / edit | success or pure dry-run | failed precondition | CLI usage error |
+| others | success | unhandled error | CLI usage error |
+
+In agent loops, check `returncode` *and* parse the JSON — `returncode != 0` plus an `issues` array tells the model what went wrong.
+
+## Common variations
+
+| You want... | Pipe through |
+|---|---|
+| Quick filter on the shell | `gmnspy validate --json src \| jq '.issues[] \| select(.severity=="error")'` |
+| One-liner in Python | `json.loads(subprocess.check_output(["gmnspy", "info", "--json", src]))` |
+| Stateful flow (sessions, history) | use MCP — see [Wire the MCP server](serve-mcp.md) |
+| Streaming output | not supported; commands emit one document on completion |
+
+## Pitfalls
+
+* **Don't parse stderr.** It's intentionally human-formatted (rich panels, colour, prompts). Mixing it into your parser breaks on the next release.
+* **Don't mix `--json` and non-`--json` calls in the same loop.** Pick one and stick to it — the model gets confused when half the tool outputs are JSON and half are panels.
+* **Auto-approve makes destructive ops silent.** `DATAGROVE_AUTO_APPROVE=1` skips every confirmation including ones the user might *want* to be asked about. Scope the env var to the agent subprocess; don't export it shell-wide.
+
+## See also
+
+* [MCP tools reference](../ai/mcp-tools.md) — richer, stateful surface for agents that can speak MCP.
+* [AI surface](../ai/index.md) — how `--json` fits with `llms.txt`, `api-index.json`, and the Claude Code Skills.

--- a/docs/cookbook/customise-quality.md
+++ b/docs/cookbook/customise-quality.md
@@ -1,0 +1,141 @@
+---
+title: Customise the data-quality rule pack
+audience: users
+kind: howto
+summary: Override thresholds, disable rules, promote severity, and register your own rule via entry point.
+---
+
+# Customise the data-quality rule pack
+
+## When to use this
+
+GMNS defaults are designed for typical mid-sized urban networks. Override them when:
+
+* Your network's speed limits, lane counts, or geometry tolerances differ from the defaults (a 30 mph residential cap, or a CRS in degrees instead of meters).
+* You want to silence a rule that's noise on your data.
+* You want to plug in a project-specific quality rule.
+
+## Quick example
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+from datagrove.quality import run_quality, RuleConfig
+
+net = Network.from_source(leavenworth.csv_dir())
+report = run_quality(
+    net,
+    config={"quality.high_speed_residential": RuleConfig(thresholds={"speed_limit_mph": 30.0})},
+)
+print(f"{len(report.issues)} issues at the lower 30 mph threshold")
+```
+
+## Step-by-step
+
+### 1. List the rules currently registered
+
+```python
+from datagrove.quality import list_rules
+
+for rule in list_rules():
+    print(f"{rule.code:42} {rule.severity.value:8} {rule.description[:50]}")
+```
+
+The GMNS rule pack registers seven rules out of the box:
+
+| Code | Threshold key | Default | Severity |
+|---|---|---|---|
+| `quality.high_speed_residential` | `speed_limit_mph` | `35` | WARNING |
+| `quality.duplicate_near_nodes` | `epsilon_units` | `1e-5` | WARNING |
+| `quality.sharp_angle_bend` | `min_angle_deg` | `30` | INFO |
+| `quality.lane_count_mismatch` | (no threshold) | — | WARNING |
+| `quality.zero_length_link` | `min_length_units` | `0.0` | WARNING |
+| `quality.disconnected_component` | `min_component_size` | `2` | INFO |
+| `quality.orphan_node` | (no threshold) | — | INFO |
+
+### 2. Override a threshold
+
+`RuleConfig.thresholds` is merged into the rule's defaults — you only specify the keys you want to change:
+
+```python
+report = run_quality(
+    net,
+    config={
+        "quality.high_speed_residential": RuleConfig(thresholds={"speed_limit_mph": 25.0}),
+        "quality.sharp_angle_bend": RuleConfig(thresholds={"min_angle_deg": 45.0}),
+    },
+)
+```
+
+### 3. Disable a rule entirely
+
+```python
+report = run_quality(
+    net,
+    config={"quality.orphan_node": RuleConfig(enabled=False)},
+)
+```
+
+A disabled rule produces no issues and isn't listed in the report.
+
+### 4. Promote (or demote) severity
+
+A common case: your CI pipeline should fail on lane-count mismatches even though the rule ships as WARNING.
+
+```python
+from datagrove.reports import Severity
+
+report = run_quality(
+    net,
+    config={"quality.lane_count_mismatch": RuleConfig(severity_override=Severity.ERROR)},
+)
+exit(1 if any(i.severity is Severity.ERROR for i in report.issues) else 0)
+```
+
+### 5. Write your own rule and register it
+
+A rule is a class with five attributes + a `run` method:
+
+```python
+from datagrove.quality import Rule, register_rule
+from datagrove.reports import Issue, Severity, Category
+
+class NoTollLinksRule(Rule):
+    code = "quality.no_toll_links"
+    description = "Project networks should not contain toll links."
+    severity = Severity.WARNING
+    applies_to = ("link",)  # which tables the rule needs
+
+    def run(self, net, config):
+        links = net.tables["link"].to_pandas()
+        for row in links[links["toll"] > 0].itertuples():
+            yield Issue(
+                code=self.code,
+                severity=config.severity_override or self.severity,
+                category=Category.DATA_QUALITY,
+                message=f"link {row.link_id} has nonzero toll",
+                table="link",
+                row=row.Index,
+                fix_hint="set toll=0 or remove from project scope",
+            )
+
+register_rule(NoTollLinksRule())
+```
+
+Or declare it via the `datagrove.quality.rules` entry point in `pyproject.toml` so it auto-registers on import:
+
+```toml
+[project.entry-points."datagrove.quality.rules"]
+no_toll_links = "myproject.rules:NoTollLinksRule"
+```
+
+## Pitfalls
+
+* **`epsilon_units` is CRS-sensitive.** The default `1e-5` is tight for WGS84 degrees (~1 metre near the equator). A network in projected meters needs something like `epsilon_units=0.5` for the same intent. Always set this explicitly for non-WGS84 networks.
+* **`severity_override` doesn't mute — it replaces.** Setting `severity_override=Severity.INFO` on a WARNING rule still produces issues; if you want to drop them, use `enabled=False`.
+* **Custom rules need `applies_to`.** A rule that touches the `signal` table without listing it in `applies_to` won't be invoked on networks that lack the table — the runner skips it silently.
+
+## See also
+
+* [Quickstart](../intro/quickstart.md#4-run-data-quality-checks) — the default quality flow.
+* [API reference](../reference/api.md) — `run_quality`, `RuleConfig`, `Rule`, `Issue`.

--- a/docs/cookbook/run-bench.md
+++ b/docs/cookbook/run-bench.md
@@ -1,0 +1,118 @@
+---
+title: Run the bundled benchmarks
+audience: users
+kind: howto
+summary: gmnspy bench measures load + validate + connectivity timings per phase on your network + hardware.
+---
+
+# Run the bundled benchmarks
+
+## When to use this
+
+You want a fast read on how `gmnspy` performs on your hardware against your network — sizing a server, comparing engines (`ibis` / `pandas` / `polars`), or tracking CI regressions over time.
+
+## Quick example
+
+```text
+$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
+{
+  "source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv",
+  "engine": "ibis",
+  "phases": [
+    {"name": "load",         "seconds": 0.082},
+    {"name": "validate",     "seconds": 0.124},
+    {"name": "quality",      "seconds": 0.041},
+    {"name": "connectivity", "seconds": 0.038}
+  ],
+  "total_seconds": 0.285
+}
+```
+
+## Step-by-step
+
+### 1. Run against the bundled reference
+
+```text
+$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+```
+
+The Leavenworth fixture is small (214 links / 75 nodes) — total runtime is under a second. It's a baseline, not a benchmark; useful for confirming nothing's wrong with the install.
+
+### 2. Run against your own network
+
+```text
+$ gmnspy bench /path/to/my/network --json > bench.json
+```
+
+Same command, different path. The bench accepts the same source surface as `Network.from_source` — local dirs, `s3://`, `duckdb://`, etc.
+
+### 3. Compare engines
+
+```text
+$ gmnspy bench /path/to/net --engine ibis --json > ibis.json
+$ gmnspy bench /path/to/net --engine pandas --json > pandas.json
+$ gmnspy bench /path/to/net --engine polars --json > polars.json
+```
+
+Typical patterns: `ibis` (the default) wins for partitioned Parquet on a fast disk; `polars` wins for CSV bulk loads; `pandas` is the slowest of the three on anything > 100k rows but is the most portable.
+
+### 4. Capture a baseline for CI
+
+For regression tracking, save a baseline JSON in-repo and compare on every PR:
+
+```text
+$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-baseline.json
+$ # in CI:
+$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-current.json
+$ python -c "
+import json
+b = json.load(open('bench-baseline.json'))['total_seconds']
+c = json.load(open('bench-current.json'))['total_seconds']
+assert c < b * 1.3, f'regression: {c:.2f}s vs baseline {b:.2f}s (+{(c/b-1)*100:.0f}%)'
+"
+```
+
+A 30% tolerance is reasonable for the Leavenworth fixture given timing noise; tighten on larger networks.
+
+### 5. Read the JSON
+
+The shape is stable inside a major version:
+
+```json
+{
+  "source": "...",
+  "engine": "ibis",
+  "spec_version": "0.97",
+  "table_counts": {"link": 214, "node": 75, "lane": 412, ...},
+  "phases": [
+    {"name": "load",         "seconds": 0.082},
+    {"name": "validate",     "seconds": 0.124},
+    {"name": "quality",      "seconds": 0.041},
+    {"name": "connectivity", "seconds": 0.038}
+  ],
+  "total_seconds": 0.285
+}
+```
+
+Each phase is one logical operation: `load` opens the package and instantiates the engine; `validate` runs structural + schema + FK + sync passes; `quality` runs the GMNS rule pack; `connectivity` builds the igraph index and counts components.
+
+## Common variations
+
+| You want... | Pipe through |
+|---|---|
+| Just the total | `jq -r .total_seconds bench.json` |
+| Phase breakdown as CSV | `jq -r '.phases[] \| [.name,.seconds] \| @csv' bench.json` |
+| CI regression check | save baseline `bench.json`; compare with `jq -e '.total_seconds < 5.0'` |
+| Engine sweep | shell loop over `--engine ibis pandas polars` with `--json` |
+
+## Pitfalls
+
+* **Micro-network timing is noisy.** On Leavenworth the absolute numbers fluctuate by ±30% between runs. Use it to confirm correctness, not for engine choice — switch to a regional-scale network before drawing conclusions.
+* **First run pays the GraphIndex build cost.** Subsequent calls hit the in-memory cache, so the second run is faster. For a representative cold-start number, restart Python between runs; for a hot-cache number, run the bench twice and take the second.
+* **`--engine polars` needs the `polars` extra.** `pip install 'gmnspy[polars]'`. Without it the CLI errors before timing anything.
+* **Quality + connectivity require `[clean]`.** A pure `pip install gmnspy` skips those phases (they show as `null` seconds in the JSON).
+
+## See also
+
+* [Convert CSV ↔ Parquet ↔ DuckDB](convert-formats.md) — the format you load from dominates `load` time.
+* [API reference](../reference/api.md) — `gmnspy.bench.run_bench` for programmatic use.

--- a/docs/cookbook/scope-bbox.md
+++ b/docs/cookbook/scope-bbox.md
@@ -1,0 +1,116 @@
+---
+title: Bounding-box and polygon scope
+audience: users
+kind: howto
+summary: Spatial scope by bbox, polygon, or geometry-buffer — works on any Frictionless package with a WKT geometry column.
+---
+
+# Bounding-box and polygon scope
+
+## When to use this
+
+You have a spatial filter — a bounding box from a map UI, a polygon from a planning area, or a buffered route — and want only the rows whose geometry falls inside it. Works on any geometry-bearing table; not GMNS-specific.
+
+## Quick example
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+from datagrove.dataset.view import from_bbox
+
+net = Network.from_source(leavenworth.csv_dir())
+view = from_bbox(net.links, minx=-120.67, miny=47.58, maxx=-120.65, maxy=47.60)
+print(f"{view.count()} links in bbox")
+```
+
+## Step-by-step
+
+### 1. Bounding box (any table)
+
+```python
+from datagrove.dataset.view import from_bbox
+
+view = from_bbox(net.links, minx=-120.67, miny=47.58, maxx=-120.65, maxy=47.60)
+df = view.to_pandas()
+```
+
+`from_bbox` is generic — it works on any `Table` whose schema declares a WKT geometry column. No shapely required for bbox; the predicate is pure coordinate math.
+
+### 2. Polygon (shapely or WKT)
+
+```python
+from datagrove.dataset.view import from_polygon
+from shapely.geometry import Polygon
+
+poly = Polygon([
+    (-120.67, 47.58),
+    (-120.65, 47.58),
+    (-120.65, 47.60),
+    (-120.67, 47.60),
+    (-120.67, 47.58),
+])
+view = from_polygon(net.links, poly)
+```
+
+If shapely isn't installed, pass a WKT string:
+
+```python
+view = from_polygon(net.links, "POLYGON((-120.67 47.58, -120.65 47.58, ...))")
+```
+
+### 3. Buffered geometry
+
+Buffer a geometry (in metres, regardless of CRS — the helper reprojects) and filter to anything inside:
+
+```python
+from datagrove.dataset.view import from_geometry_buffer
+from shapely.geometry import LineString
+
+corridor = LineString([(-120.67, 47.58), (-120.65, 47.60)])
+view = from_geometry_buffer(net.links, corridor, distance_m=100)
+```
+
+### 4. Predicate pushdown
+
+When the underlying source is partitioned Parquet, the spatial predicate compiles to a single DuckDB `WHERE` clause. Partitions whose statistics fall entirely outside the bbox are pruned before reading. Typical speed-up on a regional network is 10-50× vs full scan.
+
+```python
+net = Network.from_source("s3://my-bucket/regional/links.parquet")
+# Only the parquet partitions overlapping the bbox are read off S3.
+view = from_bbox(net.links, minx=-120.67, miny=47.58, maxx=-120.65, maxy=47.60)
+```
+
+Inspect the compiled predicate via `view.explain()` — useful when debugging "why is this slow?" against an S3 source. The explain output names every partition that was kept or pruned.
+
+### 5. Compose with other filters
+
+Spatial views compose with the rest of the `View` API:
+
+```python
+inside = from_bbox(net.links, -120.67, 47.58, -120.65, 47.60)
+arterials = inside.filter(net.links.facility_type == "arterial")
+arterials.to_pandas()
+```
+
+That filter compiles to a single SQL pass — the bbox + facility-type predicate fuse, no intermediate materialisation.
+
+## Common variations
+
+| You want... | Use |
+|---|---|
+| Filter one table | `from_bbox(net.links, ...)` returns a lazy `View` |
+| Filter the whole network | `gmnspy.scope.from_polygon(net, poly)` — FK pushdown across all tables |
+| WGS84 bbox on a projected source | reproject the bbox first; `from_bbox` doesn't reproject |
+| A buffered point | `from_geometry_buffer(net.links, Point(lon, lat), distance_m=500)` |
+
+## Pitfalls
+
+* **CRS mismatch is silent.** `from_bbox` compares numbers — degrees-vs-metres mismatches produce empty results, not errors. Check `net.spec.crs` first.
+* **`distance_m` only works if CRS is known.** If the source declares no CRS, `from_geometry_buffer` raises. Set `crs=` on the source, or pre-buffer in the geometry's native units and pass via `from_polygon`.
+* **Shapely needed for polygon input** (not bbox). `pip install gmnspy[clean]` brings it in.
+* **Single-table scope is *not* FK-aware.** If you bbox-filter `link` and want only the dependent `lane` rows too, use `gmnspy.scope.from_polygon(net, poly)` instead — that walks the FK graph.
+
+## See also
+
+* [Build a scope from seed nodes](scope-from-nodes.md) — network-graph scope (vs spatial).
+* [API reference](../reference/api.md) — `datagrove.dataset.view.from_bbox`, `from_polygon`, `from_geometry_buffer`.

--- a/docs/cookbook/scope-from-nodes.md
+++ b/docs/cookbook/scope-from-nodes.md
@@ -1,0 +1,115 @@
+---
+title: Build a scope from seed nodes
+audience: users
+kind: howto
+summary: Network-aware scope from a list of node ids — BFS path-between, FK pushdown, chainable set ops.
+---
+
+# Build a scope from seed nodes
+
+## When to use this
+
+You have a list of node ids (e.g. study-area boundary nodes, signalised intersections, a corridor's endpoints) and want the subgraph that connects them — every link on a shortest path, every dependent `lane` / `link_tod` / `signal_*` row, with foreign keys pre-filtered.
+
+## Quick example
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+from gmnspy.scope import from_nodes
+
+net = Network.from_source(leavenworth.csv_dir())
+sub = from_nodes(net, [1, 25, 50], path_between=True).apply()
+print(f"scoped: {sub.links.count()} links, {sub.nodes.count()} nodes")
+```
+
+## Step-by-step
+
+### 1. Install the `[clean]` extra
+
+```text
+$ pip install 'gmnspy[clean]'
+```
+
+`from_nodes` walks the network graph via igraph; that's in the `[clean]` extra. Without it you get an `ImportError` pointing at the missing dependency.
+
+### 2. Decide `path_between=True` vs `False`
+
+* `path_between=True` (default) — runs BFS shortest paths between every pair of seed nodes and includes all nodes + links on those paths. Gives you the *connected subgraph* containing the seeds.
+* `path_between=False` — keeps just the seed nodes and their incident links. Useful when the seeds already describe a closed region and you don't want extra interior links.
+
+### 3. Build the scope (lazy)
+
+```python
+scope = from_nodes(net, [1, 25, 50], path_between=True)
+
+print(f"nodes in scope:    {len(scope.node_ids)}")
+print(f"links in scope:    {len(scope.link_ids)}")
+print(f"provenance reason: {scope.provenance.reason}")
+```
+
+A `Scope` is a description of *which rows* belong to the subset, not the subset itself. `scope.provenance` records how it was built (operation, seeds, parameters) for audit / debugging.
+
+### 4. Apply to materialise a sub-network
+
+```python
+sub = scope.apply()
+# Every table is pre-filtered by FK chain:
+#   link             — only links in scope.link_ids
+#   node             — only nodes in scope.node_ids
+#   lane             — only lanes whose link_id ∈ scope.link_ids
+#   link_tod         — same FK pushdown
+#   signal_phase     — only phases for surviving signals
+#   ...
+```
+
+`sub` is a normal `Network` — validate it, run quality checks, write it out.
+
+### 5. Chain with set ops + buffers
+
+Scopes compose:
+
+```python
+from gmnspy.scope import from_nodes, from_point
+
+corridor = from_nodes(net, [1, 25, 50])
+downtown = from_point(net, lon=-120.66, lat=47.59, spatial_buffer="500m")
+
+combined = corridor.union(downtown).buffer_network("0.5mi")
+# .intersect(other), .subtract(other), .buffer_spatial(metres) also available
+sub = combined.apply()
+```
+
+### 6. CLI equivalent
+
+```text
+$ gmnspy scope from-nodes packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 25 50 --json
+{
+  "operation": "from_nodes",
+  "seed_node_ids": [1, 25, 50],
+  "result_node_count": 18,
+  "result_link_count": 31,
+  ...
+}
+```
+
+## Common variations
+
+| You have... | Use |
+|---|---|
+| A single seed + max distance | `from_node(net, 1, network_buffer="200m")` |
+| One link + buffer | `from_link(net, 42, spatial_buffer="100m")` (or `network_buffer=`) |
+| A lon/lat point | `from_point(net, lon, lat, spatial_buffer="500m")` (snaps to nearest link) |
+| A whole connected component | `connected_component(net, seed_node_id=1)` |
+| A zone polygon | `from_zone(net, zone_id=12)` |
+
+## Pitfalls
+
+* **Auto-build threshold.** On networks > 50k nodes the first scope call silently builds the igraph adjacency, which can take a few seconds. Pre-build with `net.build_indexes(graph=True)` to control timing, or raise the bar with `GMNSPY_AUTO_INDEX_THRESHOLD=200000`.
+* **`igraph` is in `[clean]`.** A pure `pip install gmnspy` won't import — you'll see `ImportError: gmnspy.scope requires the [clean] extra`.
+* **`path_between=True` is O(seeds²)** in BFS calls. For 100s of seeds, prefer a region scope (`from_zone`, `from_polygon`) or build the graph index first.
+
+## See also
+
+* [Bounding-box and polygon scope](scope-bbox.md) — generic spatial scope on any package.
+* [API reference](../reference/api.md) — `gmnspy.scope.from_nodes`, `Scope.apply`, `Scope.union`, ...

--- a/docs/cookbook/serve-http.md
+++ b/docs/cookbook/serve-http.md
@@ -1,0 +1,131 @@
+---
+title: Self-host the HTTP server
+audience: users
+kind: howto
+summary: Run the FastAPI server with bearer-token auth, configure packages, and stand it up behind a reverse proxy.
+---
+
+# Self-host the HTTP server
+
+## When to use this
+
+You want HTTP access to your GMNS networks — for dashboards, non-Python consumers, or a small team sharing a single curated set of packages. The server is read-only and stateless.
+
+## Quick example
+
+```yaml
+# server.yaml
+bind: 127.0.0.1
+port: 8000
+auth:
+  mode: bearer
+  token_hash: "$argon2id$v=19$..."   # generate via generate_dev_token
+packages:
+  - id: leavenworth
+    source: packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+```
+
+```text
+$ gmnspy server run --config server.yaml
+INFO:     Uvicorn running on http://127.0.0.1:8000
+```
+
+## Step-by-step
+
+### 1. Install the `[server]` extra
+
+```text
+$ pip install 'gmnspy[server]'
+```
+
+Brings in FastAPI + uvicorn + the auth dependencies.
+
+### 2. Generate a dev token
+
+```text
+$ python -c "from datagrove.api import generate_dev_token; print(generate_dev_token())"
+token:     7yK3-...-Q9p
+token_hash: $argon2id$v=19$m=65536,t=3,p=4$...
+```
+
+Save the raw `token` somewhere safe (clients need it); paste `token_hash` into your config. The raw token is never stored on the server.
+
+### 3. Write a config YAML
+
+```yaml
+# server.yaml
+bind: 127.0.0.1      # 0.0.0.0 to accept off-host requests (see pitfalls)
+port: 8000
+
+auth:
+  mode: bearer       # or "none" — see pitfalls
+  token_hash: "$argon2id$v=19$..."
+
+packages:
+  - id: leavenworth
+    source: packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+  - id: regional
+    source: s3://my-bucket/regional/datapackage.json
+    # optional: spec_version, engine, credentials cascade
+
+logging:
+  level: INFO
+```
+
+### 4. Run it + verify
+
+```text
+$ gmnspy server run --config server.yaml
+$ curl http://127.0.0.1:8000/health
+{"status": "ok", "version": "1.0.0"}
+```
+
+### 5. Make authenticated requests
+
+```text
+$ TOKEN="7yK3-...-Q9p"
+$ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/networks
+[{"id": "leavenworth", "spec_version": "0.97", "link_count": 214, ...}]
+
+$ curl -H "Authorization: Bearer $TOKEN" \
+       http://127.0.0.1:8000/networks/leavenworth/quality
+{"issues": [...], "spec_version": "0.97"}
+```
+
+### 6. Endpoint list
+
+| Endpoint | Returns |
+|---|---|
+| `GET /health` | liveness probe (no auth) |
+| `GET /packages` | configured packages |
+| `GET /packages/{id}` | one package's metadata |
+| `GET /packages/{id}/spec` | Frictionless spec JSON |
+| `POST /packages/{id}/validate` | full validation report |
+| `GET /networks` | GMNS networks only |
+| `GET /networks/{id}` | GMNS metadata + counts |
+| `POST /networks/{id}/quality` | runs the GMNS rule pack |
+
+Interactive OpenAPI at `http://127.0.0.1:8000/docs`.
+
+## Common variations
+
+| You want... | Change |
+|---|---|
+| Off-host access | `bind: 0.0.0.0` *and keep auth on* |
+| Behind nginx / Caddy | Bind to `127.0.0.1`; let the proxy terminate TLS + forward |
+| Multiple tokens (per client) | List under `auth.token_hashes:` instead of `auth.token_hash:` |
+| Disable auth (dev only) | `auth: { mode: none }` — refuses to start unless bound to localhost |
+| Docker | Dockerfile is on the Phase 5 roadmap; for now `pip install` in your own image and copy the config |
+
+## Pitfalls
+
+* **`auth: none` + non-localhost bind is a security footgun.** The server logs a loud `SECURITY WARNING` at startup and refuses to start unless you also set `auth.allow_unauthenticated_remote: true` in the config — don't.
+* **Bearer tokens are compared via constant-time HMAC** against the stored Argon2 hash. Don't compare raw tokens elsewhere in your stack.
+* **Stateless server, lazy engine.** Each request loads the package fresh through the lazy ibis engine. Big networks may want a connection pool / cache layer in front; the server doesn't ship one.
+* **No write endpoints.** The HTTP server is read-only by design. For editing, use the Python API + `Session`, or wait for the deferred write surface.
+
+## See also
+
+* [Wire the MCP server to Claude Code / Claude Desktop](serve-mcp.md) — same data, stdio transport.
+* [MCP tools reference](../ai/mcp-tools.md) — what the MCP surface exposes.
+* [API reference](../reference/api.md) — `datagrove.api.generate_dev_token`, server config schema.


### PR DESCRIPTION
## Summary

Second batch of cookbook fill — 6 new task-oriented howto recipes plus the complete MCP tools reference page. Pairs with the first cookbook batch + the 5-recipe fill PR.

Pages added:

- **`docs/cookbook/customise-quality.md`** (141 lines) — `RuleConfig` threshold overrides, disable / promote severity, write + register a custom rule via the `datagrove.quality.rules` entry point. Includes the 7-default-rules table.
- **`docs/cookbook/scope-from-nodes.md`** (115 lines) — `from_nodes(net, [...], path_between)` with FK pushdown; chainable union / intersect / buffer ops; CLI equivalent; auto-build threshold pitfall.
- **`docs/cookbook/scope-bbox.md`** (116 lines) — generic spatial scope on any Frictionless package: `from_bbox`, `from_polygon`, `from_geometry_buffer`; partitioned-Parquet predicate pushdown.
- **`docs/cookbook/serve-http.md`** (131 lines) — `generate_dev_token`, server config YAML, endpoint table, bearer-auth + non-localhost-bind warnings.
- **`docs/cookbook/run-bench.md`** (118 lines) — `gmnspy bench`, engine sweep (ibis / pandas / polars), CI baseline tracking, phase JSON shape.
- **`docs/cookbook/ai-json-cli.md`** (117 lines) — every command's `--json` contract, `DATAGROVE_AUTO_APPROVE` for agent loops, schema-stability + exit-code reference.
- **`docs/ai/mcp-tools.md`** (247 lines) — `kind: reference` page for all 7 MCP tools (4 generic from `datagrove.mcp` + 3 GMNS-aware): parameters, return shape, one example per tool.

## Test plan

- [x] `uv run mkdocs build` — no new warnings on the 7 added pages. Remaining warnings point at the 5 deferred recipes (`serve-mcp`, `convert-formats`, etc.), filled by a separate PR.
- [x] `uv run pytest` — 857 passed, 48 skipped (polars-not-installed; pre-existing).
- [x] Every page conforms to `docs/_page-style-guide.md` frontmatter + section order.
- [x] All Python blocks use the bundled Leavenworth fixture.

## Base

Targeting `feat/4.13-docs-polish` (not `refactor/v1.0`).

Do NOT merge — waiting for review alongside the sibling batch.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>