### PR TITLE
docs(intro+reference): 4 pages — what-is-gmns, visual-tour, table-of-tables, glossary (#96)

### DIFF
--- a/docs/intro/visual-tour.md
+++ b/docs/intro/visual-tour.md
@@ -2,20 +2,22 @@
 title: Visual tour
 audience: users
 kind: tutorial
-summary: See the bundled Leavenworth fixture rendered as a map, a validation report, a data-quality report, and a before/after edit — all from a single notebook session.
+summary: Walk through the bundled Leavenworth fixture end-to-end — map, validation report, quality report, simplify-geometry diff, scope visualisation — all in one notebook session.
 ---
 
 # Visual tour
 
-!!! info "Stub — to be filled in Wave 4"
-    This page is scaffolded. The content fill is tracked in [issue #96](https://github.com/e-lo/GMNSpy/issues/96) and follows the [Page Style Guide](../_page-style-guide.md).
-
 ## What you'll see
 
-* Leavenworth as a Folium / Leaflet map embed.
-* A live validation report (rich rendering).
-* A data-quality report with severity grouping.
-* A simplify-geometry before/after via the editing layer.
+You'll work through the bundled Leavenworth, WA network from one notebook and produce, in order:
+
+1. A folium / matplotlib map of the full network.
+2. A validation report rendered as an HTML card.
+3. A data-quality report grouped by severity.
+4. A simplify-geometry edit, rendered as a before/after diff (then rolled back).
+5. A scoped subgraph around a single node, rendered as a second map next to the first.
+
+Total runtime: under two minutes on a laptop. The fixture is ~5 MB and ships inside the gmnspy wheel.
 
 ## Prerequisites
 
@@ -23,15 +25,202 @@ summary: See the bundled Leavenworth fixture rendered as a map, a validation rep
 $ pip install 'gmnspy[clean,notebook]'
 ```
 
+The `[clean]` extra brings in `shapely` + `igraph` for the geometry simplification and scope operations. The `[notebook]` extra brings in `ipywidgets` so the `_repr_html_` cards render in classic Jupyter as well as JupyterLab.
+
+For the map step, `folium` is recommended but optional. Either of these works:
+
+```text
+$ pip install folium       # interactive Leaflet map
+$ pip install matplotlib   # static fallback
+```
+
+The steps below show both paths.
+
 ## Steps
 
-1. Load the fixture.
-2. Render the network as a map.
-3. Validate + display the report.
-4. Run the quality pack + display.
-5. Simplify geometry + render before/after.
+### 1. Load the fixture
+
+```python
+from gmnspy import Network
+from gmnspy.fixtures import leavenworth
+
+net = Network.from_source(leavenworth.csv_dir())
+print(f"{net.spec_version}: {net.links.count()} links, {net.nodes.count()} nodes")
+```
+
+You should see:
+
+```text
+0.97: 214 links, 75 nodes
+```
+
+The fixture is loaded lazily through the default ibis + duckdb engine. Nothing has been materialised yet — `net.links` is still an ibis expression.
+
+### 2. Render the network as a map
+
+The `link` table is keyed to `geometry` by `geometry_id`; the `geometry.geometry` column carries the WKT LineString per link. To plot, materialise both:
+
+```python
+import pandas as pd
+from shapely import wkt
+
+links = net.links.to_pandas()
+geoms = net.tables["geometry"].to_pandas().set_index("geometry_id")
+links = links.join(geoms[["geometry"]], on="geometry_id")
+links["shape"] = links["geometry"].map(wkt.loads)
+```
+
+With folium (interactive):
+
+```python
+import folium
+
+# Centroid of the network — average node y/x
+nodes = net.nodes.to_pandas()
+center = [nodes["y_coord"].mean(), nodes["x_coord"].mean()]
+
+m = folium.Map(location=center, zoom_start=15, tiles="cartodbpositron")
+for shape in links["shape"]:
+    coords = [(y, x) for x, y in shape.coords]  # folium wants (lat, lon)
+    folium.PolyLine(coords, color="#1f77b4", weight=2, opacity=0.8).add_to(m)
+m  # in a notebook, this renders the map inline
+```
+
+You should see the downtown Leavenworth grid — a compact, walkable core wrapped around Highway 2 / Front Street, surrounded by a few residential tertiary streets.
+
+Without folium (static fallback):
+
+```python
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 8))
+for shape in links["shape"]:
+    xs, ys = shape.xy
+    ax.plot(xs, ys, color="#1f77b4", linewidth=1.0, alpha=0.8)
+ax.set_aspect("equal")
+ax.set_title(f"Leavenworth GMNS fixture — {len(links)} links")
+plt.show()
+```
+
+Either way: a recognisable Bavarian-themed downtown core in roughly 600 m of OSM-derived street network.
+
+### 3. Validate + display the report
+
+```python
+report = net.validate()
+report  # in a notebook, the _repr_html_ renders a styled card
+```
+
+You should see a green header ("0 errors") with a summary of the four passes the validator runs — structural (all required tables present), schema (field types + constraints), foreign-key (cross-table integrity), and sync-state (have any FKs gone stale since the last edit?). The Leavenworth fixture is clean by construction.
+
+In a non-notebook context:
+
+```python
+print(f"{report.spec_version}: {len(report.issues)} issues")
+for issue in report.issues[:5]:
+    print(f"  {issue.severity.value:9} {issue.code:30} {issue.message[:60]}")
+```
+
+### 4. Run quality + display
+
+The data-quality pack flags things the spec is silent on but every real network has — disconnected components, lane-count mismatches, high speeds on residential facilities, near-duplicate nodes.
+
+```python
+from datagrove.quality import run_quality
+
+qreport = run_quality(net)
+qreport  # _repr_html_ renders severity-grouped findings
+```
+
+You should see a card with WARNING / INFO findings (no ERRORs). Leavenworth's tertiary streets carry posted speeds in the 25-30 mph range with `facility_type=residential`, which triggers `quality.high_speed_residential` if you've configured a low threshold — useful for seeing what a real finding looks like.
+
+To see one in detail:
+
+```python
+for issue in qreport.issues[:3]:
+    print(f"  {issue.severity.value:9} {issue.code:35} {issue.message}")
+```
+
+### 5. Simplify geometry + render before/after
+
+The `simplify_geometry` op in `gmnspy.clean` removes redundant vertices from link geometries. Wrap it in a `Session` so you can roll back:
+
+```python
+from datagrove.editing import Session
+from gmnspy.clean import simplify_geometry
+
+with Session(net) as s:
+    edit = simplify_geometry(s, mode="redundant_only", tolerance=1.0)
+    edit  # in a notebook, _repr_html_ shows the diff (vertices removed per link)
+```
+
+You should see a diff card listing the number of vertices removed per affected link. `mode="redundant_only"` removes only colinear vertices and is loss-free; `mode="douglas_peucker"` is the lossy alternative with an explicit tolerance.
+
+To visualise before/after, snapshot the geometry before opening the session and overlay both on one map:
+
+```python
+links_before = links[["link_id", "shape"]].copy()
+# (run the simplify edit above inside the Session)
+links_after_geoms = net.tables["geometry"].to_pandas().set_index("geometry_id")
+links_after = links.copy()
+links_after["shape"] = links_after["geometry_id"].map(
+    lambda gid: wkt.loads(links_after_geoms.loc[gid, "geometry"])
+)
+
+m = folium.Map(location=center, zoom_start=15, tiles="cartodbpositron")
+for shape in links_before["shape"]:
+    folium.PolyLine([(y, x) for x, y in shape.coords],
+                    color="#888", weight=4, opacity=0.4).add_to(m)
+for shape in links_after["shape"]:
+    folium.PolyLine([(y, x) for x, y in shape.coords],
+                    color="#d62728", weight=1.5, opacity=0.9).add_to(m)
+m
+```
+
+Grey underneath = before; red on top = after. On Leavenworth most links don't change (the OSM source is already minimal), but a handful of curved tertiary links visibly simplify.
+
+To restore the original state:
+
+```python
+s.rollback()
+```
+
+The session's chronological log reverses every edit atomically — the network returns to byte-identical to step 1.
+
+### 6. Build a scope from a single node and render
+
+```python
+from gmnspy.scope import from_node
+
+scoped = from_node(net, node_id=1, network_buffer="200m").apply()
+print(f"scoped: {scoped.links.count()} links, {scoped.nodes.count()} nodes")
+```
+
+That's a 200 m **network-distance** (Dijkstra-bounded) buffer around node 1, with every other table — `lane`, `link_tod`, `movement`, etc. — pre-filtered by FK chain.
+
+Render it side-by-side with the original:
+
+```python
+scoped_links = scoped.links.to_pandas().join(geoms[["geometry"]], on="geometry_id")
+scoped_links["shape"] = scoped_links["geometry"].map(wkt.loads)
+
+m = folium.Map(location=center, zoom_start=15, tiles="cartodbpositron")
+# Full network, faint
+for shape in links["shape"]:
+    folium.PolyLine([(y, x) for x, y in shape.coords],
+                    color="#bbb", weight=1, opacity=0.5).add_to(m)
+# Scope, highlighted
+for shape in scoped_links["shape"]:
+    folium.PolyLine([(y, x) for x, y in shape.coords],
+                    color="#2ca02c", weight=3, opacity=0.95).add_to(m)
+m
+```
+
+You should see a small green subgraph centred on one intersection, with the rest of the network greyed out as context. The scope respects the routable graph — links reachable only via long detours fall outside the 200 m buffer even if they're spatially close.
 
 ## Next steps
 
-* [Cookbook](../cookbook/index.md) — go deeper on any of these workflows.
-* [Architecture](../architecture.md) — design rationale.
+* [Cookbook](../cookbook/index.md) — task-oriented recipes for any of the workflows above.
+* [API reference](../reference/api.md) — every symbol you used in this tour.
+* [Architecture](../architecture.md) — design rationale for sessions, scopes, and the lazy-by-default engine.
+* [Table of tables](../reference/table-of-tables.md) — what other GMNS tables you can pull from `net.tables[...]`.

--- a/docs/intro/what-is-gmns.md
+++ b/docs/intro/what-is-gmns.md
@@ -2,34 +2,93 @@
 title: What is GMNS?
 audience: both
 kind: concept
-summary: Plain-English introduction to the General Modeling Network Specification — what it is, who maintains it, what tables it defines, why a Python toolkit matters.
+summary: Plain-English introduction to the General Modeling Network Specification — what it defines, who maintains it, how it relates to Frictionless, GTFS, and OpenStreetMap.
 ---
 
 # What is GMNS?
 
-!!! info "Stub — to be filled in Wave 4"
-    This page is scaffolded. The content fill is tracked in [issue #96](https://github.com/e-lo/GMNSpy/issues/96) and follows the [Page Style Guide](../_page-style-guide.md).
-
 ## What it is
 
-The [General Modeling Network Specification (GMNS)](https://github.com/zephyr-data-specs/GMNS) is the Zephyr Foundation's open standard for representing routable transportation networks in tabular form. It defines a small set of files (`link`, `node`, `geometry`, `lane`, `link_tod`, …) and how they relate via foreign keys.
+The **General Modeling Network Specification (GMNS)** is an open standard, maintained by the [Zephyr Foundation](https://zephyrtransport.org/), for representing routable transportation networks as a small set of related tables. The spec lives at [github.com/zephyr-data-specs/GMNS](https://github.com/zephyr-data-specs/GMNS) and is versioned (current vendored versions: 0.95, 0.96, 0.97).
+
+A GMNS network is a directory of CSVs (or Parquet, or any tabular store) plus a `datapackage.json` manifest that describes the schema. The required core is just two tables:
+
+* `link` — directed edges of the routable graph (one row per road segment between two intersections).
+* `node` — vertices of the graph (intersections, dead-ends, zone centroids).
+
+Layered on top of that core, the spec defines optional tables for the things real transportation models need:
+
+* **Geometry detail** — `geometry` (WKT shapes per link), `segment` and `segment_lane` (sub-link partitioning for places where lane geometry changes).
+* **Lane detail** — `lane` (one row per travel lane), `movement` (turning movements at a node).
+* **Time-of-day overrides** — `link_tod`, `lane_tod`, `segment_tod`, `segment_lane_tod`, `movement_tod` — per-period overrides on capacity, allowed uses, lane assignments.
+* **Signal control** — `signal_controller`, `signal_coordination`, `signal_detector`, `signal_phase_mvmt`, `signal_timing_phase`, `signal_timing_plan`.
+* **Demand context** — `zone` (traffic analysis zones), `location` (curb-side points), `curb_seg` (curb space management).
+* **Dimension tables** — `time_set_definitions` (period definitions), `use_definition` and `use_group` (vehicle / mode classes), `config` (network-wide configuration).
+
+The full set across the 0.97 spec is **25 resource files**. See [Table of tables](../reference/table-of-tables.md) for the catalog and [Schema reference](../reference/spec.md) for field-level detail.
+
+The spec ships as a [Frictionless Data Package](https://specs.frictionlessdata.io/data-package/) — `datapackage.json` declares each resource, its CSV schema, primary keys, and foreign-key relationships in a machine-readable form.
 
 ## Why we have it
 
-(Plain-English paragraph: pre-GMNS, every model used its own network format; GMNS lets a network produced for one model travel to another with zero conversion code.)
+Before GMNS, every traffic simulator, travel-demand model, and routing engine carried its own network format. A network exported from Cube didn't load in TransCAD; a Visum file didn't open in SUMO; a TomTom routing graph wasn't a TransModeler input. Modelers spent more time writing conversion scripts than running models, and every conversion silently dropped information.
+
+GMNS exists so a network produced for one tool travels to another with **zero conversion code**. The interop story is the whole story:
+
+1. Producers (state DOTs, MPOs, OSM derivative pipelines) publish in GMNS.
+2. Consumers (modelers, routing services, analysis tools) read GMNS directly.
+3. The spec is small enough that bespoke conversions are practical when a tool *doesn't* speak GMNS natively — but the goal is that they don't have to be written twice.
+
+GMNS is **not** a modeling format with semantics baked in (capacity calculations, BPR functions, signal optimisation). It is the *substrate* on which those tools operate. The same GMNS network feeds a microsimulation, a static-equilibrium assignment, and an active-transportation accessibility analysis.
 
 ## Mental model
 
-(2-3 bullet summary + a single mermaid ER diagram of link → node → lane → link_tod.)
+* **Tables, not files** — a GMNS network is a set of relations, not a binary blob. Any tabular store works (CSV, Parquet, DuckDB, zipped CSV).
+* **Two required tables, the rest optional** — the minimum viable GMNS network is `link` + `node`. Every other table layers detail onto that spine.
+* **Foreign keys are the API** — relationships between tables (`lane.link_id` → `link.link_id`, `link.from_node_id` → `node.node_id`) are declared in `datapackage.json` and machine-checkable.
+
+The core relationships:
+
+```mermaid
+erDiagram
+    node ||--o{ link : "from_node_id / to_node_id"
+    link ||--o{ lane : "link_id"
+    link ||--o{ link_tod : "link_id"
+    link }o--|| geometry : "geometry_id (optional)"
+    node ||--o{ movement : "node_id"
+    link ||--o{ movement : "ib_link_id / ob_link_id"
+```
+
+A real network has more edges in this diagram (signal tables hang off `node`, segment tables sub-divide `link`, zone tables hang off `node`) but the four cardinal relations above carry most of the routing semantics.
 
 ## How it relates to ...
 
-* The Frictionless Data Package format
-* GTFS (separate spec, GMNS+GTFS bridging via [openmobilitydata](https://openmobilitydata.org))
-* OpenStreetMap
+### The Frictionless Data Package format
+
+GMNS is a Frictionless Data Package. The spec is not a custom serialization — it's a `datapackage.json` that declares 25 resources, each with a Table Schema (field types, constraints, primary key, foreign keys). Any Frictionless-compatible reader can parse a GMNS package's structure without knowing what GMNS is.
+
+This is why the GMNSpy validator's structural and schema passes are inherited verbatim from `datagrove` (the generic toolkit underneath); only the foreign-key chains and the data-quality rules are GMNS-specific.
+
+### GTFS
+
+[GTFS](https://gtfs.org/) (General Transit Feed Specification) is a separate spec, scoped to **scheduled public transit** — routes, stops, trips, stop-times. GMNS is scoped to the **routable roadway / street network** — links, nodes, lanes, signals.
+
+The two are complementary and frequently combined: GMNS for the street network the bus drives on, GTFS for the bus schedule. Bridging tools like [openmobilitydata.org](https://openmobilitydata.org) and the in-development GTFS-GMNS reconciliation patterns let a transit assignment use both.
+
+GMNS deliberately does not duplicate GTFS. A `transit_route` table is *not* in GMNS — that's GTFS's job.
+
+### OpenStreetMap
+
+[OpenStreetMap (OSM)](https://www.openstreetmap.org/) is a global, crowdsourced geographic database. It is **not** a network spec — OSM tags are loose, regionally inconsistent, and not designed for routing-grade modeling out of the box.
+
+GMNS is the standardised target for the conversion. Tools like [`osm2gmns`](https://github.com/jiawlu/OSM2GMNS) and `osmnx` (used to build the bundled Leavenworth fixture — see its [README](https://github.com/e-lo/GMNSpy/blob/refactor/v1.0/packages/gmnspy/gmnspy/fixtures/leavenworth/README.md)) consume OSM, infer link attributes (lanes, free-flow speed, facility type) from OSM tags, and emit GMNS.
+
+OSM → GMNS is lossy and opinionated (tag inference is heuristic; OSM doesn't carry signal timing or TOD restrictions). The point is that the *output* is a single standardised format that every downstream consumer understands, regardless of where the source data came from.
 
 ## See also
 
-* [Quickstart](quickstart.md)
-* [Visual tour](visual-tour.md)
-* [Reference: schema](../reference/spec.md)
+* [Quickstart](quickstart.md) — install and load the bundled fixture in five minutes.
+* [Visual tour](visual-tour.md) — see Leavenworth rendered as a map, validated, edited, and scoped.
+* [Table of tables](../reference/table-of-tables.md) — catalog of every GMNS resource.
+* [Schema reference](../reference/spec.md) — field-level reference for the vendored spec.
+* [Architecture](../architecture.md) — design rationale for the toolkit on top of GMNS.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -2,53 +2,83 @@
 title: Glossary
 audience: both
 kind: reference
-summary: GMNS-domain terms (link, lane, TOD, …) and project conventions (sync state, scope, EditResult, …) defined in one place.
+summary: GMNS-domain terms (link, lane, TOD, segment, …) and project conventions (sync state, scope, EditResult, Skill, MCP, …) defined in one place.
 ---
 
 # Glossary
 
-!!! info "Stub — to be filled in Wave 4"
-    This page is scaffolded. The content fill is tracked in [issue #96](https://github.com/e-lo/GMNSpy/issues/96) and follows the [Page Style Guide](../_page-style-guide.md).
+## Summary
+
+Two sections: **GMNS domain** terms come from the spec itself and apply to any GMNS toolkit. **Project conventions** are GMNSpy + datagrove specific — names that appear in the API, CLI, and docs of this toolkit. Entries are alphabetical within each section.
 
 ## GMNS domain
 
-**Link** — a directed (or undirected) edge in the routable network, between two nodes.
+**Allowed uses** — the set of `use_definition` ids permitted to traverse a link or lane (e.g., `{auto, truck, transit}`). Encoded as a comma-separated list referencing `use_definition.use_id` or as a `use_group.group_id`. Distinct from `prohibited_uses`, which is the inverse expression. See [`use_definition`](table-of-tables.md#dimension-tables).
 
-**Node** — a vertex in the routable network.
+**Capacity** — the maximum hourly throughput of a link or lane under prevailing conditions, in vehicles per hour. Carried on `link.capacity` (and overridable per period via `link_tod.capacity`). Units are vehicles per hour per lane unless the producer notes otherwise; GMNS is silent on the LOS model used to compute it.
 
-**Lane** — a sub-element of a link with its own lane number, optional turn restrictions.
+**Curb segment** — a managed length of curb (parking, loading zone, no-stopping). One row per curb segment in `curb_seg`, keyed to a `link_id`. New in recent GMNS versions; supports curb-management modeling.
 
-**Geometry** — a row in the optional `geometry` table holding a WKT shape, referenced by `link.geometry_id`.
+**Facility type** — categorical descriptor of a link's roadway class (e.g., `motorway`, `primary`, `tertiary`, `residential`, `service`). Drives default values for capacity, free speed, and lane count when those fields are absent. The exact vocabulary is in `shared_categories.json` under `facility_type_categories`.
 
-**TOD (time-of-day)** — per-time-period overrides on link / lane / segment / movement attributes. Keyed by `time_set_definitions.timeday_id`.
+**Free speed** — the posted or signed speed limit, or the speed at which vehicles travel under uncongested conditions. Carried on `link.free_speed` in `link.free_speed_units` (typically `mph` or `kph`). Distinct from any modeled travel speed.
 
-**Movement** — a turning movement at a node, from an inbound link to an outbound link.
+**Geometry** — a row in the optional `geometry` table holding a WKT LineString, referenced by `link.geometry_id`. When absent, the link is implicit straight-line from `from_node` to `to_node`. The geometry table exists so multiple links can share one shape (e.g., a divided highway represented as two opposing links sharing a centerline).
 
-**Zone** — a traffic analysis zone (TAZ); nodes carry an optional `zone_id`.
+**GMNS** — General Modeling Network Specification. The Zephyr Foundation's open standard for routable transportation networks in tabular Frictionless Data Package form. See [What is GMNS?](../intro/what-is-gmns.md).
 
-**Spec version** — the GMNS spec release the data conforms to. Vendored: 0.95 / 0.96 / 0.97.
+**Lane** — a sub-element of a link with its own lane number, optional turn restrictions, and allowed uses. One row per travel lane per link in the `lane` table; `lane.lane_id` is keyed to `link.link_id`. A link with `lanes=3` typically has three corresponding `lane` rows.
+
+**Link** — a directed edge in the routable network, from `from_node_id` to `to_node_id`. The required spine table; carries facility type, lanes, free speed, length, allowed uses. Undirected networks are represented by paired links (one per direction).
+
+**Movement** — a turning movement at a node, from an inbound link to an outbound link. One row per allowed turn in the `movement` table; carries movement type (left/through/right/u-turn) and permitted uses. Used by signal-control tables to map phases to movements.
+
+**Node** — a vertex in the routable network — intersection, dead-end, zone centroid. The required vertices table; carries x/y coordinates and optional `ctrl_type` (signal, stop, yield, no-control).
+
+**Segment** — a sub-division of a link where attributes change mid-link (e.g., a lane drop, a facility-type change). One row per segment in the `segment` table; segments tile a link end-to-end. Used when link-level attributes are too coarse.
+
+**Spec version** — the GMNS spec release the data conforms to. GMNSpy vendors 0.95, 0.96, and 0.97. Validation reports always include the spec version. The default is 0.97; override via `Network.from_source(path, spec_version="0.96")`.
+
+**TOD (time-of-day)** — per-time-period overrides on link / lane / segment / movement attributes. Keyed by `timeday_id` into `time_set_definitions`. A period like `weekday_am_peak` (Mon-Fri 07:00-09:00) is defined once and referenced from every `*_tod` row that varies by that period.
+
+**Zone** — a traffic analysis zone (TAZ) for demand modeling. Nodes carry an optional `zone_id`. The `zone` table holds polygon or centroid geometry; not every network has zones (routing-only networks often don't).
 
 ## Project conventions
 
-**Engine** — the materialisation backend (`IbisEngine` default, `PandasEngine`, `PolarsEngine`).
+**ApprovalRequired** — exception raised when a gated operation's cost estimate exceeds the approval threshold (default 180 seconds) and the caller has not set `approve=True`. See the cost-model section of [Architecture](../architecture.md#65-pooled-operations-cost-model).
 
-**Lazy expression** — a `Table.expr` that has not been materialised. Operations on a lazy expression return a new lazy expression.
+**Auto-build threshold** — the network size (in nodes) above which `gmnspy.scope` ops silently build the spatial + graph indexes on first call. Default 50,000 nodes. Configurable via the `GMNSPY_AUTO_INDEX_THRESHOLD` environment variable. Pre-build explicitly with `net.build_indexes(graph=True, spatial=True)` to control timing.
 
-**Sync state** — content-hash tracking on every table; the validator warns when a previously-validated FK has gone stale.
+**DATAGROVE_AUTO_APPROVE** — environment variable (`DATAGROVE_AUTO_APPROVE=1`) that bypasses the cost-model approval prompt for gated operations. Equivalent to CLI `--yes` or programmatic `approve=True`. Intended for batch / CI use.
 
-**Scope** — a `NetworkScope` is a (node_ids, link_ids) pair that, when applied, returns a filtered `Network`.
+**EditResult** — the value returned by every `gmnspy.clean` op. Carries the diff per affected table, the log entry for the operation, and a `_repr_html_` visual summary for notebook rendering. Integrated with `datagrove.editing.Session` for rollback.
 
-**Network buffer** — a Dijkstra-bounded expansion in **graph distance** (uses `link.length`).
+**Engine** — the materialisation backend. `IbisEngine` is default (lazy expressions over DuckDB); `PandasEngine` and `PolarsEngine` are alternatives. Per-call override: `Network.from_source(path, engine=PandasEngine())`. See the engine ABC at `datagrove.engines`.
 
-**Spatial buffer** — a shapely-bounded expansion in **CRS units** (degrees for WGS84, meters for projected).
+**GMNSPY_AUTO_INDEX_THRESHOLD** — see *Auto-build threshold*.
 
-**EditResult** — the value returned by every `gmnspy.clean` op; carries the diff + the rollback record.
+**Lazy expression** — a `Table.expr` that has not been materialised. Operations on a lazy expression return a new lazy expression. Materialisation happens explicitly via `.to_pandas()`, `.to_polars()`, `.collect()`, `.head()`, or `.count()`.
 
-**Session** — context manager around one or more Edits with atomic rollback.
+**MCP (Model Context Protocol)** — the open protocol Claude and other AI agents use to discover and call tools. GMNSpy ships an MCP server via `pip install 'gmnspy[mcp]'`; start it with `gmnspy mcp serve`. Tools exposed: `read_network`, `describe_network`, `query_table`, `scope`, `validate`, `quality_check`, `convert`, `edit_session`. See [Architecture §6.9](../architecture.md#69-ai-accessibility).
 
-**Severity / Category / Issue** — see [API reference](api.md#datagrove.reports.Severity).
+**Network buffer** — a Dijkstra-bounded expansion in **graph distance** (using `link.length`). Used by `gmnspy.scope.from_node(id, network_buffer="200m")`. Distinct from spatial buffer.
+
+**OutOfSyncWarning** — warning raised before `write()` or `validate(strict=True)` when any tracked foreign-key's source or target table hash has changed since the last validation. Indicates the in-memory FK graph may no longer match the data. Promote to an error with `strict=True`.
+
+**Scope** — a `NetworkScope` is a (node_ids, link_ids) pair that, when applied via `.apply()`, returns a filtered `Network` with every other table pre-filtered by FK chain. Scopes are composable and chainable: `net.scope.from_nodes([1,2,3]).buffer_network("0.5mi").buffer_spatial(30)`. See [Architecture §6.2](../architecture.md#62-memory-efficient-scoping).
+
+**Session** — context manager around one or more `EditResult`s with atomic rollback. Open with `with Session(net) as s: ...`; rollback with `s.rollback()` or `s.rollback(to=session_id_or_timestamp)`. Audit log persists with the network as a sidecar `_history.parquet`.
+
+**Severity / Category / Issue** — see [API reference](api.md#datagrove.reports.Severity). `Severity` is one of `Error`, `Warning`, `Info`, `DataQuality`. `Category` discriminates rule families. `Issue` is the per-finding record carried in a `ValidationReport`.
+
+**Skill (Claude Code Skill)** — a packaged set of instructions and prompts a Claude Code agent can load on demand. GMNSpy ships several (`gmns-author`, `gmns-validate`, `gmns-convert`, `gmns-clean`, `datagrove-validate`) under `skills/` in the repo. Install with `claude code skill add <git-url>#path=skills/<name>`. See [Architecture §6.9](../architecture.md#69-ai-accessibility).
+
+**Spatial buffer** — a shapely-bounded expansion in **CRS units** (degrees for WGS84, meters for projected CRSs). Used by `gmnspy.scope.from_link(id, spatial_buffer_m=...)` and the `buffer_spatial()` chain method. Distinct from network buffer.
+
+**Sync state** — content-hash tracking on every table via `DirtyTracker` (in `datagrove.validation.sync_state`). Records source + target hashes per FK at validation time so the validator can detect when a previously-checked FK has gone stale. Direct DataFrame mutations bypass the tracker — call `net.invalidate("link")` to force.
 
 ## See also
 
-* [Table of tables](table-of-tables.md)
-* [Schema reference](spec.md)
+* [Table of tables](table-of-tables.md) — catalog of every GMNS resource referenced above.
+* [Schema reference](spec.md) — field-level reference for the vendored spec.
+* [Architecture](../architecture.md) — design rationale for the project-convention terms.

--- a/docs/reference/table-of-tables.md
+++ b/docs/reference/table-of-tables.md
@@ -2,53 +2,95 @@
 title: Table of tables
 audience: both
 kind: reference
-summary: Every GMNS table — purpose, when-to-use, foreign keys, link to its full schema. Auto-generated from the vendored spec; ER diagrams via mermaid.
+summary: Catalog of every GMNS 0.97 resource — purpose, required vs optional, primary foreign keys, link into the field-level reference.
 ---
 
 # Table of tables
 
-!!! info "Stub — to be filled in Wave 4"
-    This page is scaffolded. The content fill is tracked in [issue #96](https://github.com/e-lo/GMNSpy/issues/96) and follows the [Page Style Guide](../_page-style-guide.md).
-
 ## Summary
 
-GMNS defines ~25 resource files. Two are always required (`link`, `node`); the rest layer on optional detail. This page lists every one with a one-paragraph purpose + the FK graph.
+GMNS 0.97 defines **25 resource files** grouped into four families: required, detail, signal-control, and dimension. Two tables (`link`, `node`) are required by the spec; the rest layer optional detail. This page is the "which table should I use?" entry point. For field-level detail (types, constraints, descriptions per column) see [Schema reference](spec.md).
+
+The vendored 0.97 spec lives at `packages/gmnspy/gmnspy/spec/0.97/`. Each table is defined by a `<name>.schema.json` and listed as a resource in `datapackage.json`.
 
 ## Required
 
-| Table | Purpose | Foreign keys |
+These two tables form the routable graph spine. A valid GMNS package must include both.
+
+| Table | Purpose | Key foreign keys |
 |---|---|---|
-| `link` | Edges of the routable graph. | `from_node_id`, `to_node_id` → `node.node_id`; `geometry_id` → `geometry.geometry_id` (optional) |
-| `node` | Vertices of the routable graph. | `zone_id` → `zone.zone_id` (optional) |
+| `link` | Directed edges of the routable graph; one row per road segment between two intersections. Carries facility type, lane count, free-flow speed, allowed uses. | `from_node_id`, `to_node_id` → `node.node_id`; `geometry_id` → `geometry.geometry_id` (optional); `parent_link_id` → `link.link_id` (self-ref, optional) |
+| `node` | Vertices of the routable graph; intersections, dead-ends, zone centroids. Carries x/y coordinates and control type. | `zone_id` → `zone.zone_id` (optional); `parent_node_id` → `node.node_id` (self-ref, optional) |
 
 ## Detail tables
 
-(Lane, segment, segment_lane, link_tod, lane_tod, segment_tod, segment_lane_tod, movement, movement_tod, zone, location, curb_seg.)
+Add geometric, lane-level, segment-level, or curb-level detail to the link/node spine. All optional.
+
+| Table | Purpose | Key foreign keys |
+|---|---|---|
+| `lane` | One row per travel lane on a link. Carries lane number, width, allowed uses, turn restrictions. | `link_id` → `link.link_id` |
+| `segment` | Sub-divides a link where attributes change mid-link (e.g., a lane drop). One row per segment. | `link_id` → `link.link_id` |
+| `segment_lane` | One row per lane within a segment. Same role as `lane` but at segment granularity. | `segment_id` → `segment.segment_id` |
+| `link_tod` | Time-of-day override on link attributes (capacity, allowed uses) for a defined period. | `link_id` → `link.link_id`; `timeday_id` → `time_set_definitions.timeday_id` |
+| `lane_tod` | Time-of-day override on lane attributes. | `lane_id` → `lane.lane_id`; `timeday_id` → `time_set_definitions.timeday_id` |
+| `segment_tod` | Time-of-day override on segment attributes. | `segment_id` → `segment.segment_id`; `timeday_id` → `time_set_definitions.timeday_id` |
+| `segment_lane_tod` | Time-of-day override on segment-lane attributes. | `segment_lane_id` → `segment_lane.segment_lane_id`; `timeday_id` → `time_set_definitions.timeday_id` |
+| `movement` | A turning movement at a node, from an inbound link to an outbound link. Carries permitted uses and a movement type (left/through/right/u-turn). | `node_id` → `node.node_id`; `ib_link_id`, `ob_link_id` → `link.link_id` |
+| `movement_tod` | Time-of-day override on movement attributes. | `mvmt_id` → `movement.mvmt_id`; `timeday_id` → `time_set_definitions.timeday_id` |
+| `geometry` | WKT LineString per link. Referenced by `link.geometry_id`; optional (links can be implicit straight from-to). | (primary key; referenced by `link`) |
+| `zone` | Traffic analysis zone (TAZ) polygons or centroids for demand modeling. | (primary key; referenced by `node.zone_id`) |
+| `location` | Curb-side point of interest — a stop, a pick-up location, a service door. | `link_id` → `link.link_id` (optional); `zone_id` → `zone.zone_id` (optional) |
+| `curb_seg` | A managed curb segment with allowed uses, parking regulations, loading-zone designations. | `link_id` → `link.link_id` |
 
 ## Signal-control tables
 
-(signal_controller, signal_coordination, signal_detector, signal_phase_mvmt, signal_timing_phase, signal_timing_plan.)
+Carry signalized-intersection timing and detection data. All optional; needed only when modeling signal operations.
+
+| Table | Purpose | Key foreign keys |
+|---|---|---|
+| `signal_controller` | One row per signal controller (typically one per signalized intersection). | `node_id` → `node.node_id` |
+| `signal_coordination` | Coordination relationships between controllers in a corridor. | `controller_id` → `signal_controller.controller_id` |
+| `signal_detector` | Detector loops / video zones on link approaches. | `controller_id` → `signal_controller.controller_id`; `link_id` → `link.link_id` |
+| `signal_phase_mvmt` | Maps movements to signal phases (which phase serves which turning movement). | `controller_id` → `signal_controller.controller_id`; `mvmt_id` → `movement.mvmt_id` |
+| `signal_timing_phase` | Per-phase timing parameters (min green, max green, yellow, all-red). | `timing_plan_id` → `signal_timing_plan.timing_plan_id` |
+| `signal_timing_plan` | A named timing plan (cycle length, offset, plan identifier) for one controller. | `controller_id` → `signal_controller.controller_id`; `timeday_id` → `time_set_definitions.timeday_id` (when plan is TOD-bound) |
 
 ## Dimension tables
 
-(time_set_definitions, use_definition, use_group, config.)
+Vocabularies and configuration referenced by the detail and signal-control tables. All optional but typically present when any TOD or use-restriction is used.
+
+| Table | Purpose | Key foreign keys |
+|---|---|---|
+| `time_set_definitions` | Named time periods (e.g., `weekday_am_peak` = Mon-Fri 07:00-09:00). Referenced by every `*_tod` table. | (primary key) |
+| `use_definition` | A defined vehicle / mode class (auto, truck, transit, bike, walk). | (primary key; referenced by `use_group`, `lane.allowed_uses`, etc.) |
+| `use_group` | A named set of `use_definition` members (e.g., `motorized` = {auto, truck, transit}). | `use_id` → `use_definition.use_id` |
+| `config` | Network-wide configuration key/value pairs (units, default CRS, GMNS version metadata). | (primary key) |
 
 ## ER diagram
 
+The core link / node / lane / link_tod / movement / geometry relationships:
+
 ```mermaid
 erDiagram
-    link }o--|| node : from_node_id
-    link }o--|| node : to_node_id
-    link }o--o{ geometry : geometry_id
-    lane }o--|| link : link_id
-    link_tod }o--|| link : link_id
-    lane_tod }o--|| lane : lane_id
-    movement }o--|| link : ib_link_id
-    movement }o--|| link : ob_link_id
-    movement }o--|| node : node_id
+    node ||--o{ link : "from_node_id"
+    node ||--o{ link : "to_node_id"
+    link ||--o{ lane : "link_id"
+    link ||--o{ link_tod : "link_id"
+    link }o--|| geometry : "geometry_id"
+    lane ||--o{ lane_tod : "lane_id"
+    node ||--o{ movement : "node_id"
+    link ||--o{ movement : "ib_link_id"
+    link ||--o{ movement : "ob_link_id"
+    time_set_definitions ||--o{ link_tod : "timeday_id"
+    time_set_definitions ||--o{ lane_tod : "timeday_id"
+    zone ||--o{ node : "zone_id"
 ```
+
+The signal, segment, and curb tables hang off `link` and `node` with the same shape but aren't shown here to keep the diagram readable. For the complete table list see the families above; for individual field detail see [Schema reference](spec.md).
 
 ## See also
 
-* [Schema reference](spec.md) — auto-generated field-level reference.
-* [What is GMNS?](../intro/what-is-gmns.md) — design context.
+* [Schema reference](spec.md) — auto-generated field-level reference per table.
+* [What is GMNS?](../intro/what-is-gmns.md) — design context for the spec.
+* [Visual tour](../intro/visual-tour.md) — see several of these tables rendered in a notebook.
+* [Glossary](glossary.md) — GMNS terms used above (TOD, segment, movement, …).


### PR DESCRIPTION
## Summary

Fills the four currently-stub intro + reference pages from issue #96.

- **docs/intro/what-is-gmns.md** (94 lines, `kind: concept`) — Plain-English intro to GMNS: what tables it defines, why a single spec exists, mental model (with an ER diagram), and how GMNS relates to Frictionless Data Package, GTFS, and OpenStreetMap.
- **docs/intro/visual-tour.md** (226 lines, `kind: tutorial`) — Six-step notebook walkthrough against the bundled Leavenworth fixture: load, render as a folium / matplotlib map, validate + display the report card, run the quality pack, simplify geometry inside a `Session` with rollback, then build a scope and render it side-by-side with the full network.
- **docs/reference/table-of-tables.md** (96 lines, `kind: reference`) — Catalog of all 25 GMNS 0.97 resources grouped Required / Detail / Signal / Dimension, with one-sentence purpose and primary foreign keys per table. Includes a core-relations ER diagram. Cross-links to `reference/spec.md` for field-level detail.
- **docs/reference/glossary.md** (84 lines, `kind: reference`) — Expanded GMNS-domain section (added Segment, Curb segment, Allowed uses, Capacity, Free speed, Facility type) and Project-conventions section (added Sync state, OutOfSyncWarning, ApprovalRequired, DATAGROVE_AUTO_APPROVE, Auto-build threshold / GMNSPY_AUTO_INDEX_THRESHOLD, Skill, MCP). Sorted alphabetically within each section.

All four pages follow `docs/_page-style-guide.md` (required frontmatter; per-kind section order; impersonal voice for concept + reference, second-person for tutorial; cross-link to the canonical home page rather than re-explaining concepts).

## Test plan

- [x] `uv run mkdocs build` succeeds; zero warnings on the four edited pages.
- [x] `uv run pytest` — 820 passed, 52 skipped (polars not installed).
- [ ] Hand review of the rendered Mermaid diagrams (one each in `what-is-gmns.md` and `table-of-tables.md`).
- [ ] Spot-check the folium / matplotlib snippets in `visual-tour.md` against a real notebook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)