### PR TITLE
fix(review): PR-C doctor adds installed: bool to extras checks (#171)

### DIFF
--- a/packages/gmnspy/gmnspy/cli/app.py
+++ b/packages/gmnspy/gmnspy/cli/app.py
@@ -678,17 +678,40 @@ _EXTRA_PROBES: tuple[tuple[str, str], ...] = (
 
 
 def _check_optional_extras() -> list[dict[str, object]]:
-    """One check per (extra, probe-module). ``ok=False`` is informational, not fatal — see _check_leavenworth_loads."""
+    """Probe each optional [extra] for importability. Adds ``installed: bool`` to each check.
+
+    Schema (per check)::
+
+        {
+            "name": "extra:<extra-name>[<module>]",
+            "ok": bool,         # True = check passed (importable OR allowed-absent)
+            "installed": bool,  # True = the module was importable; False = absent
+            "detail": str,      # human-readable status
+        }
+
+    All optional extras have ``ok=True`` regardless of installed state — being
+    absent is not a failure for an OPTIONAL extra. But agents reading ``--json``
+    can now branch on ``installed`` to find what's actually present (the literal
+    presence/absence signal previously hidden inside the ``detail`` string).
+    """
     out: list[dict[str, object]] = []
     for extra, module in _EXTRA_PROBES:
         try:
             importlib.import_module(module)
-            out.append({"name": f"extra:{extra}[{module}]", "ok": True, "detail": "importable"})
+            out.append(
+                {
+                    "name": f"extra:{extra}[{module}]",
+                    "ok": True,
+                    "installed": True,
+                    "detail": "importable",
+                }
+            )
         except ImportError as exc:
             out.append(
                 {
                     "name": f"extra:{extra}[{module}]",
                     "ok": True,  # optional — absence is not a failure
+                    "installed": False,
                     "detail": f"not installed ({exc.__class__.__name__}); install with `uv sync --extra {extra}`",
                 }
             )

--- a/packages/gmnspy/tests/test_cli_spec_doctor.py
+++ b/packages/gmnspy/tests/test_cli_spec_doctor.py
@@ -89,3 +89,23 @@ def test_doctor_json_mode():
         assert isinstance(check["name"], str)
         assert isinstance(check["ok"], bool)
         assert isinstance(check["detail"], str)
+
+
+def test_doctor_extras_check_includes_installed_field():
+    """`doctor --json` extras checks carry `installed: bool` agents can filter on."""
+    result = runner.invoke(app, ["doctor", "--json"])
+    # Doctor may exit non-zero on actual failures; --json shape still must be parseable.
+    payload = json.loads(result.stdout)
+    extras = [c for c in payload if c["name"].startswith("extra:")]
+    assert len(extras) >= 1, "doctor should report at least one extras check"
+    assert all("installed" in c for c in extras), "every extras check should carry an `installed: bool` field"
+    assert all(isinstance(c["installed"], bool) for c in extras)
+
+
+def test_doctor_extras_ok_stays_true_when_extra_absent():
+    """Optional extras keep ok=True when absent — installed=False is the agent-readable signal."""
+    result = runner.invoke(app, ["doctor", "--json"])
+    payload = json.loads(result.stdout)
+    extras = [c for c in payload if c["name"].startswith("extra:")]
+    # All optional extras report ok=True regardless of installed state.
+    assert all(c["ok"] is True for c in extras)


### PR DESCRIPTION
## Summary

Fixes #171. Batch A review (Lens B I-3) flagged that `gmnspy doctor --json` reports `ok=True` for both installed AND absent optional extras, with the literal status hidden inside the `detail` string. Agents using the JSON output couldn't filter for missing extras with the natural query `jq '[.checks[] | select(.ok == false)]'`.

This adds an explicit `installed: bool` field alongside `ok` so JSON consumers can branch on literal presence/absence. `ok` semantics are unchanged (optional extras stay `ok=True` regardless of installed state) to preserve existing exit-code behavior — the new field is purely additive.

### Changes
- `packages/gmnspy/gmnspy/cli/app.py`: `_check_optional_extras()` now includes `installed: bool` in each emitted dict; expanded docstring documents the schema.
- `packages/gmnspy/tests/test_cli_spec_doctor.py`: two new tests pin the new field and the ok-semantics.

### Example
```
$ gmnspy doctor --json | jq '.[] | select(.name | startswith("extra:")) | {name, ok, installed}'
{
  "name": "extra:clean[shapely]",
  "ok": true,
  "installed": true
}
...
```

## Test plan
- [x] `uv run pytest packages/gmnspy/tests/test_cli_spec_doctor.py -v` (7 passed)
- [x] `uv run pytest` (876 passed, 48 skipped)
- [x] `uv run ruff check packages/ scripts/ main.py`
- [x] `uv run ruff format --check packages/ scripts/ main.py`
- [x] `uv run lint-imports` (2 kept, 0 broken)
- [x] `uv run python scripts/lint_no_sql.py`
- [x] Smoke: `uv run gmnspy doctor --json | jq` shows `installed` field on every `extra:*` check

Generated with [Claude Code](https://claude.com/claude-code)