### PR TITLE
docs(v2): quickstarts + visual tour + what-is-gmns rewritten (#96 v2)

### DIFF
--- a/docs/datagrove/quickstart.md
+++ b/docs/datagrove/quickstart.md
@@ -7,31 +7,170 @@ summary: Install, load any Frictionless data package, validate it, scope it, and
 
 # Quickstart — datagrove
 
-!!! info "Stub — to be filled in docs Wave D-2"
-    This page is scaffolded. The fill is tracked in this docs polish wave; it follows the [Page Style Guide](../_page-style-guide.md) `kind: howto` template, with prose-before-code on every example, accordion-style "Common variations", and screenshots of the validation report card.
-
 ## When to use this
 
-You want to load + validate + scope a Frictionless data package — any spec, not just GMNS — and see what datagrove gives you in five minutes.
+You want to load + validate + (optionally) spatially scope a Frictionless data package — any spec, not just GMNS — and see what `datagrove` gives you in five minutes. If you're working with GMNS networks specifically, the [gmnspy quickstart](../gmnspy/quickstart.md) is the better starting point; everything here applies underneath that surface.
 
 ## Quick example
 
-(One short paragraph describing what we're about to do, THEN the code, THEN the expected output.)
+The fastest way to confirm `datagrove` is wired up is to load a real Frictionless package, run the four-pass validator, and print a one-line summary. The example below uses the bundled Leavenworth GMNS fixture as a stand-in for "any Frictionless package" — the API is identical regardless of spec.
+
+```bash
+pip install datagrove
+```
+
+Then in Python:
+
+```python
+from datagrove import Package
+from gmnspy.fixtures import leavenworth  # any Frictionless dir works here
+
+pkg = Package.from_source(leavenworth.csv_dir(), spec=leavenworth.spec_path())
+report = pkg.validate()
+print(f"{len(pkg.tables)} tables, {len(report.issues)} validation issues")
+```
+
+Expected:
+
+```text
+25 tables, 0 validation issues
+```
+
+You just loaded a Frictionless data package through the default ibis + DuckDB engine, then ran the structural / schema / FK / sync-state validator in a single call. Nothing was eagerly materialised — `pkg.tables["link"]` is still a lazy expression.
 
 ## Step-by-step
 
-1. Install
-2. Load the bundled Leavenworth fixture (or any datapackage.json)
-3. Validate
-4. Scope (spatial bbox / polygon)
-5. Write out
+### 1. Install
+
+`datagrove` has no optional extras — every dependency is core, and one pip install is enough.
+
+```bash
+pip install datagrove
+```
+
+### 2. Load a Frictionless package
+
+`Package.from_source` accepts a local path, an `s3://` / `https://` / `duckdb://` URL, or a directory of CSV / Parquet / DuckDB / zip-CSV files. The example below loads the bundled Leavenworth fixture, which is a CSV directory. Because a CSV-only directory doesn't carry a `datapackage.json` manifest, pass `spec=` explicitly to tell `datagrove` which schema to validate against.
+
+```python
+from datagrove import Package
+from gmnspy.fixtures import leavenworth
+
+pkg = Package.from_source(
+    leavenworth.csv_dir(),
+    spec=leavenworth.spec_path(),
+)
+```
+
+You should see something like:
+
+```python
+>>> pkg
+<Package: 25 tables, source=.../leavenworth/csv>
+```
+
+Substitute any other Frictionless package — your own spec, a GTFS feed converted to a Frictionless package, or a cloud-hosted parquet partition — and the rest of the steps below are identical.
+
+### 3. Validate and read the report
+
+Validation runs four passes in one call — **structural** (required resources present), **schema** (field types and constraints), **foreign-key** (cross-table integrity), and **sync-state** (have FKs gone stale since a previous edit?). The result is one `ValidationReport` with severity-graded issues.
+
+```python
+report = pkg.validate()
+print(f"{len(report.issues)} issues across {len(pkg.tables)} tables")
+
+for issue in report.issues[:5]:
+    print(f"  {issue.severity.value:9} {issue.code:30} {issue.message[:60]}")
+```
+
+In a Jupyter notebook, evaluating `report` on its own renders an HTML card grouped by severity. In a script, you can also serialise to JSON for CI:
+
+```python
+report.to_json("validation.json")
+```
+
+### 4. Scope to a spatial subset
+
+If your package has a geometry column (any WKT or WKB), `datagrove.dataset.view.from_bbox` returns a lazy view filtered to features inside a bounding box. The example below scopes the Leavenworth `link` table to a small bbox around the historic core.
+
+```python
+from datagrove.dataset.view import from_bbox
+
+links = pkg.tables["link"]
+scoped_links = from_bbox(
+    links,
+    bbox=(-120.665, 47.594, -120.655, 47.600),  # (minx, miny, maxx, maxy)
+    geometry_table=pkg.tables["geometry"],
+    geometry_fk="geometry_id",
+)
+print(f"scoped: {scoped_links.count()} links")
+```
+
+The filter pushes down to DuckDB — only the matching rows are read.
+
+### 5. Write the package out
+
+`pkg.write(dest)` round-trips the package to a new location. The output format is inferred from the extension: `.parquet` for a Parquet directory, `.duckdb` for a single-file DuckDB, or a directory for CSV.
+
+```python
+pkg.write("./out.parquet")
+```
+
+The `datapackage.json` manifest is regenerated alongside the data, so the written-out package is itself a valid Frictionless package.
 
 ## Common variations
 
-Accordions covering different engines, different formats, different sources.
+Each accordion below is one alternative to the defaults used above. The first (most common) is expanded; the rest are collapsed — open the one that matches your situation.
+
+???+ note "Switch the backend engine to pandas or polars"
+    Default is `IbisEngine` (lazy, DuckDB-backed). Switch to pandas for eager DataFrame ergonomics, or polars when you want fast in-memory analytics.
+
+    ```python
+    from datagrove.engines.pandas_engine import PandasEngine
+    # from datagrove.engines.polars_engine import PolarsEngine
+
+    pkg = Package.from_source(path, spec=spec, engine=PandasEngine())
+    ```
+
+??? note "Read from S3 with credentials"
+    Credentials resolve via a cascade: keyword arg → `DATAGROVE_CRED_<host>_TOKEN` env var → OS keyring → `.netrc`. No code changes needed if the environment is set up.
+
+    ```python
+    pkg = Package.from_source(
+        "s3://bucket/path/datapackage.json",
+    )
+    ```
+
+??? note "Load only a subset of tables"
+    Pass `tables=` to materialise only the tables you need — useful when the package is large and you only care about a few resources.
+
+    ```python
+    pkg = Package.from_source(
+        path,
+        spec=spec,
+        tables=["link", "node", "geometry"],
+    )
+    ```
+
+??? note "Pass the spec from a URL or another package"
+    `spec=` accepts a local path, a URL, or an already-loaded `Spec` object. Useful for sharing a spec across many sibling datasets.
+
+    ```python
+    pkg = Package.from_source(
+        path,
+        spec="https://example.org/specs/my-spec/datapackage.json",
+    )
+    ```
+
+## Pitfalls
+
+* **No `datapackage.json` in your directory → pass `spec=` explicitly.** CSV-only fixtures and ad-hoc directories don't carry a manifest, so `datagrove` can't infer the schema. Point `spec=` at the canonical `datapackage.json` for your data. See [Frictionless data packages](../shared/concepts/frictionless.md) for the spec-vs-data distinction.
+* **Credential cascade order matters.** Per-call `credentials=` always wins; otherwise `DATAGROVE_CRED_<host>_TOKEN` env var, then OS keyring, then `.netrc`. If you've stashed a token in two places, the higher-priority one is the one that gets used.
+* **Lazy vs eager engine behaviour.** `IbisEngine` (default) doesn't materialise until you call `.execute()` / `.to_pandas()` / `.count()`. `PandasEngine` materialises every table at load time. Use ibis for regional-scale data; switch to pandas only when you actually need the DataFrame in memory.
 
 ## See also
 
-* [Cookbook](cookbook/index.md)
-* [API reference](reference/api.md)
-* [Architecture](../shared/architecture.md)
+* [Cookbook](cookbook/index.md) — task-oriented recipes (read from S3, convert formats, spatial scope).
+* [API reference](reference/api.md) — every public symbol with stable anchors.
+* [Architecture](../shared/architecture.md) — defaults, rationales, extension points.
+* [Frictionless data packages](../shared/concepts/frictionless.md) — the spec `datagrove` builds on.

--- a/docs/gmnspy/quickstart.md
+++ b/docs/gmnspy/quickstart.md
@@ -13,30 +13,45 @@ You're new to `gmnspy` and want to see what it does on a real GMNS network befor
 
 ## Quick example
 
-```text
-$ pip install 'gmnspy[clean]'
-$ python -c "
+The fastest way to confirm `gmnspy` is wired up correctly is to install it, load the bundled Leavenworth, WA fixture, and print a one-line summary. The whole sequence runs in under thirty seconds on a cold cache.
+
+```bash
+pip install 'gmnspy[clean]'
+```
+
+Then in Python:
+
+```python
 from gmnspy import Network
 from gmnspy.fixtures import leavenworth
+
 net = Network.from_source(leavenworth.csv_dir())
-print(f'{net.spec_version}: {net.links.count()} links, {net.nodes.count()} nodes')
-"
+print(f"{net.spec_version}: {net.links.count()} links, {net.nodes.count()} nodes")
+```
+
+Expected:
+
+```text
 0.97: 214 links, 75 nodes
 ```
 
-You just loaded the bundled Leavenworth WA network through the default ibis + duckdb engine. Nothing was materialised — `net.links` is a lazy expression.
+You just loaded the bundled Leavenworth network through the default ibis + DuckDB engine. Nothing was materialised — `net.links` is a lazy expression; only the integer count came back from DuckDB to Python.
 
 ## Step-by-step
 
 ### 1. Install
 
-```text
-$ pip install 'gmnspy[clean]'
+Pick the extras you need. The `[clean]` extra brings in `shapely` and `igraph` so the geometry and connectivity ops work; a plain `pip install gmnspy` is enough for read-only validation work.
+
+```bash
+pip install 'gmnspy[clean]'
 ```
 
-The `[clean]` extra brings in `shapely` + `igraph` so the connectivity + geometry ops work. For a pure-read install, plain `pip install gmnspy` is enough.
+`datagrove` comes along as a transitive dependency — you don't install both packages.
 
 ### 2. Load the bundled fixture
+
+The fixture is a small real network (Leavenworth, WA — roughly 600 m of OSM-derived street grid) bundled inside the `gmnspy` wheel, so the example below runs without any download. `Network.from_source` accepts the same surface as `datagrove.Package.from_source`: local paths, URLs (`s3://`, `https://`, `duckdb://`), or directories of CSV / Parquet / DuckDB / zip-CSV.
 
 ```python
 from gmnspy import Network
@@ -45,24 +60,44 @@ from gmnspy.fixtures import leavenworth
 net = Network.from_source(leavenworth.csv_dir())
 ```
 
-The fixture is a small real network (Leavenworth, WA) bundled with the package. `Network.from_source` accepts the same surface as `datagrove.Package.from_source`: local paths, URLs (`s3://`, `https://`, `duckdb://`), or directories of CSV / Parquet / DuckDB / zip-CSV.
+The result is a lazy `Network` object — its tables haven't been read yet. Print a quick summary to confirm it loaded:
 
-You should see something like:
+```python
+print(f"{net.spec_version}: {net.links.count()} links, {net.nodes.count()} nodes")
+```
+
+Expected:
 
 ```text
 0.97: 214 links, 75 nodes
 ```
 
+In a Jupyter notebook, evaluating `net` on its own renders an HTML summary card with the spec version, table counts, and a thumbnail map.
+
+#### Outputs
+
+![Network summary card for the Leavenworth fixture](../assets/screenshots/leavenworth-network-card.png){ .screenshot }
+*Network summary card (`net._repr_html_()` rendered in a notebook). Shows spec version, table inventory with row counts, and a thumbnail of the link geometry.*
+
 ### 3. Validate against the spec
+
+Validation runs four passes in a single call: **structural** (required tables and files), **schema** (per-field types and constraints), **foreign-key** (cross-table integrity), and **sync-state** (have any FKs gone stale since a previous edit?). The Leavenworth fixture is clean by construction, so you should see zero ERROR-severity findings.
 
 ```python
 report = net.validate()
 print(f"issues: {len(report.issues)} ({report.spec_version})")
 ```
 
-The validator runs four passes — structural (required tables / files), schema (field types + constraints), foreign-key (cross-table integrity), sync-state (have any FKs gone stale since a previous edit?). The Leavenworth fixture is clean; expect zero ERROR-severity findings.
+In a notebook, `report` on its own renders an HTML card grouped by severity.
+
+#### Outputs
+
+![Validation report card for the Leavenworth fixture](../assets/screenshots/leavenworth-validation-report.png){ .screenshot }
+*Validation report card (`report._repr_html_()` rendered in a notebook). Zero ERRORs since Leavenworth is clean; a few DATA_QUALITY warnings from the residential-speed rule.*
 
 ### 4. Run data-quality checks
+
+The data-quality rule pack covers things the spec is silent on but every real network gets wrong sooner or later — high-speed-residential, lane-count mismatch, sharp-angle bends, near-duplicate nodes, disconnected components, implausible v/c ratios, missing critical fields. Findings come back as WARNING or INFO by default.
 
 ```python
 from datagrove.quality import run_quality
@@ -72,9 +107,14 @@ for issue in qreport.issues[:5]:
     print(f"  {issue.severity.value:9} {issue.code:35} {issue.message[:60]}")
 ```
 
-This runs the GMNS rule pack: high-speed-residential, lane-count-mismatch, sharp-angle-bends, etc. Findings are WARNING / INFO by default — the spec is silent on these, but they're frequent data-quality misses.
+#### Outputs
+
+![Quality report card for the Leavenworth fixture](../assets/screenshots/leavenworth-quality-report.png){ .screenshot }
+*Quality report card (`qreport._repr_html_()` rendered in a notebook). Severity-grouped findings — Leavenworth's tertiary streets with 25-30 mph posted speeds trip the `quality.high_speed_residential` rule when configured with a low threshold.*
 
 ### 5. Scope to a subgraph
+
+The scope module lets you carve a smaller network out of a larger one without writing FK-pushdown SQL by hand. `from_node` builds a network-distance-bounded subgraph around a seed node; every related table (`lane`, `link_tod`, `movement`, signal control) is pre-filtered so the result is still a self-consistent GMNS network.
 
 ```python
 from gmnspy.scope import from_node
@@ -83,37 +123,89 @@ scoped = from_node(net, 1, network_buffer="200m").apply()
 print(f"scoped: {scoped.links.count()} links, {scoped.nodes.count()} nodes")
 ```
 
-That's a 200-metre network-distance buffer around node 1. The returned `Network` has every table pre-filtered by FK chain — only `link_tod` / `lane` rows whose `link_id` survived the scope are kept.
+That's a 200-metre Dijkstra-bounded buffer around node 1.
+
+#### Outputs
+
+![Scoped subgraph rendered next to the full Leavenworth network](../assets/screenshots/leavenworth-scoped-map.png){ .screenshot }
+*Scope visualisation. The 200 m network-distance buffer around node 1 (highlighted green) over the full Leavenworth network (grey context). Spatially nearby links that are only reachable via long detours fall outside the buffer.*
 
 ### 6. Or run the same thing from the CLI
 
-Every command supports `--json` for piping into scripts or AI agents:
+The CLI mirrors the Python API one-for-one. The same fixture lives at `packages/gmnspy/gmnspy/fixtures/leavenworth/csv` in the repo, so you can point the CLI at it directly.
 
-```text
-$ gmnspy info --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
-$ gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
-$ gmnspy quality --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
-$ gmnspy scope from-node packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 --network-buffer 200m
+```bash
+gmnspy info packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+gmnspy validate packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+gmnspy quality packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+gmnspy scope from-node packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 --network-buffer 200m
+```
+
+By default `gmnspy` prints colorized tables and panels for humans. Add `--json` and you get a single machine-readable JSON document on stdout instead — useful for scripting, CI checks, or feeding the output to an AI agent.
+
+```bash
+gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv | jq '.issues | length'
 ```
 
 ## Common variations
 
-| You want... | Change |
-|---|---|
-| A different GMNS spec version | `Network.from_source(path, spec_version="0.96")` |
-| A different backend engine | `Network.from_source(path, engine=PandasEngine())` |
-| Read from S3 with credentials | `Network.from_source("s3://bucket/net/")` — credentials cascade: kwarg → `DATAGROVE_CRED_<host>_TOKEN` env → keyring → `.netrc` |
-| Write the scoped network out | `scoped.write("./scoped.parquet")` |
-| Run the data-quality pack with custom thresholds | `from datagrove.quality import RuleConfig; run_quality(net, config={"quality.high_speed_residential": RuleConfig(thresholds={"speed_limit_mph": 30.0})})` |
+Each accordion below is one alternative to the defaults used above. The first (most common) is expanded; the rest are collapsed — open the one that matches your situation.
+
+???+ note "Pick a different GMNS spec version"
+    The vendored versions are 0.95, 0.96, and 0.97; default is 0.97. Networks load against the version they were written against — no silent upgrades.
+
+    ```python
+    net = Network.from_source(path, spec_version="0.96")
+    ```
+
+??? note "Switch the backend engine to pandas"
+    Default is `IbisEngine` (lazy, DuckDB-backed). Switch to pandas when you need eager evaluation or DataFrame ergonomics for downstream code.
+
+    ```python
+    from datagrove.engines.pandas_engine import PandasEngine
+
+    net = Network.from_source(path, engine=PandasEngine())
+    ```
+
+??? note "Read from S3 with credentials"
+    Credentials resolve via a cascade: keyword arg → `DATAGROVE_CRED_<host>_TOKEN` env var → OS keyring → `.netrc`. No code changes if your environment is already set up.
+
+    ```python
+    net = Network.from_source("s3://bucket/network/")
+    ```
+
+??? note "Write the scoped network out"
+    The output format follows the file extension — `.parquet`, `.duckdb`, or a directory for CSV.
+
+    ```python
+    scoped.write("./scoped.parquet")
+    ```
+
+??? note "Run the data-quality pack with custom thresholds"
+    Per-rule config keys override defaults. The example below tightens the residential-speed threshold to 30 mph.
+
+    ```python
+    from datagrove.quality import RuleConfig, run_quality
+
+    qreport = run_quality(
+        net,
+        config={
+            "quality.high_speed_residential": RuleConfig(
+                thresholds={"speed_limit_mph": 30.0}
+            )
+        },
+    )
+    ```
 
 ## Pitfalls
 
-* **Auto-build of the graph index on large networks** — the first `from_node` / `connected_component` call on a > 50k-node network silently builds the igraph adjacency. Pre-build with `net.build_indexes(graph=True)` if you want to control timing, or set `GMNSPY_AUTO_INDEX_THRESHOLD` to raise the silent-build bar.
-* **Duplicate-near-nodes default is tight** (`epsilon_units=1e-5`). Networks in WGS84 degrees barely trigger it; networks in projected meters need an explicit threshold via `RuleConfig`.
-* **Editing requires a `Session`**. Don't mutate tables directly — open `with datagrove.editing.Session(net) as s:` and pass `s` into the `gmnspy.clean.*` ops. The cookbook recipe walking through this is being filled in this wave.
+* **Auto-build of the graph index on large networks.** The first `from_node` or `connected_component` call on a network larger than ~50k nodes silently builds the igraph adjacency. Pre-build with `net.build_indexes(graph=True)` if you want to control the timing, or set `GMNSPY_AUTO_INDEX_THRESHOLD` to raise the silent-build bar.
+* **Duplicate-near-nodes default threshold is tight** (`epsilon_units=1e-5`). Networks in WGS84 degrees barely trigger it; networks in projected meters need an explicit threshold via `RuleConfig`.
+* **Editing requires a `Session`.** Don't mutate tables directly — open `with datagrove.editing.Session(net) as s:` and pass `s` into the `gmnspy.clean.*` ops. The cookbook recipe walking through this is being filled in this wave.
 
 ## See also
 
 * [Cookbook](cookbook/index.md) — task-oriented recipes for the common workflows.
+* [Visual tour](visual-tour.md) — see every step above rendered as maps, cards, and diffs in a notebook.
 * [API reference](reference/api.md) — every symbol you saw above.
 * [Architecture](../shared/architecture.md) — design rationale for the defaults.

--- a/docs/gmnspy/visual-tour.md
+++ b/docs/gmnspy/visual-tour.md
@@ -7,31 +7,31 @@ summary: Walk through the bundled Leavenworth fixture end-to-end — map, valida
 
 # Visual tour
 
-## What you'll see
+## What you'll build
 
-You'll work through the bundled Leavenworth, WA network from one notebook and produce, in order:
+You'll work through the bundled Leavenworth, WA network in one notebook session and produce, in order:
 
 1. A folium / matplotlib map of the full network.
 2. A validation report rendered as an HTML card.
 3. A data-quality report grouped by severity.
 4. A simplify-geometry edit, rendered as a before/after diff (then rolled back).
-5. A scoped subgraph around a single node, rendered as a second map next to the first.
+5. A scoped subgraph around a single node, rendered side-by-side with the original.
 
-Total runtime: under two minutes on a laptop. The fixture is ~5 MB and ships inside the gmnspy wheel.
+Total runtime: under two minutes on a laptop. The fixture is ~5 MB and ships inside the `gmnspy` wheel.
 
 ## Prerequisites
 
-```text
-$ pip install 'gmnspy[clean,notebook]'
+The `[clean]` extra brings in `shapely` + `igraph` for geometry simplification and scope operations. The `[notebook]` extra brings in `ipywidgets` so the `_repr_html_` cards render in classic Jupyter as well as JupyterLab.
+
+```bash
+pip install 'gmnspy[clean,notebook]'
 ```
 
-The `[clean]` extra brings in `shapely` + `igraph` for the geometry simplification and scope operations. The `[notebook]` extra brings in `ipywidgets` so the `_repr_html_` cards render in classic Jupyter as well as JupyterLab.
+For the map steps, either `folium` (interactive Leaflet) or `matplotlib` (static fallback) works — pick one:
 
-For the map step, `folium` is recommended but optional. Either of these works:
-
-```text
-$ pip install folium       # interactive Leaflet map
-$ pip install matplotlib   # static fallback
+```bash
+pip install folium       # interactive Leaflet map
+pip install matplotlib   # static fallback
 ```
 
 The steps below show both paths.
@@ -39,6 +39,8 @@ The steps below show both paths.
 ## Steps
 
 ### 1. Load the fixture
+
+Start by loading the bundled Leavenworth network. `Network.from_source` returns a lazy `Network` — no rows have been read from disk yet; `net.links` is still an ibis expression.
 
 ```python
 from gmnspy import Network
@@ -54,11 +56,14 @@ You should see:
 0.97: 214 links, 75 nodes
 ```
 
-The fixture is loaded lazily through the default ibis + duckdb engine. Nothing has been materialised yet — `net.links` is still an ibis expression.
+In a notebook, evaluating `net` on its own renders an HTML summary card with the spec version, table inventory, and a thumbnail map.
+
+![Network summary card for the Leavenworth fixture](../assets/screenshots/leavenworth-network-card.png){ .screenshot }
+*Network summary card (`net._repr_html_()`). Spec version 0.97, 25 tables, 214 links / 75 nodes, with a thumbnail of the link geometry.*
 
 ### 2. Render the network as a map
 
-The `link` table is keyed to `geometry` by `geometry_id`; the `geometry.geometry` column carries the WKT LineString per link. To plot, materialise both:
+The `link` table is keyed to `geometry` by `geometry_id`; the `geometry.geometry` column carries the WKT LineString per link. Materialise both with `.to_pandas()` and join them before plotting.
 
 ```python
 import pandas as pd
@@ -70,7 +75,7 @@ links = links.join(geoms[["geometry"]], on="geometry_id")
 links["shape"] = links["geometry"].map(wkt.loads)
 ```
 
-With folium (interactive):
+For an interactive Leaflet map, use folium. Compute the centroid from the node table, then add one PolyLine per link.
 
 ```python
 import folium
@@ -88,7 +93,10 @@ m  # in a notebook, this renders the map inline
 
 You should see the downtown Leavenworth grid — a compact, walkable core wrapped around Highway 2 / Front Street, surrounded by a few residential tertiary streets.
 
-Without folium (static fallback):
+![Leavenworth network rendered on a folium map](../assets/screenshots/leavenworth-folium-map.png){ .screenshot }
+*Folium map of the full Leavenworth fixture. The compact downtown grid is visible around Highway 2, with tertiary residential streets fanning out.*
+
+If `folium` isn't available, the static matplotlib fallback gives an equivalent view (without basemap tiles):
 
 ```python
 import matplotlib.pyplot as plt
@@ -104,16 +112,21 @@ plt.show()
 
 Either way: a recognisable Bavarian-themed downtown core in roughly 600 m of OSM-derived street network.
 
-### 3. Validate + display the report
+### 3. Validate and display the report
+
+`net.validate()` runs the four-pass validator (structural / schema / FK / sync-state) and returns a `ValidationReport`. In a notebook, evaluating the report on its own renders a styled HTML card.
 
 ```python
 report = net.validate()
 report  # in a notebook, the _repr_html_ renders a styled card
 ```
 
-You should see a green header ("0 errors") with a summary of the four passes the validator runs — structural (all required tables present), schema (field types + constraints), foreign-key (cross-table integrity), and sync-state (have any FKs gone stale since the last edit?). The Leavenworth fixture is clean by construction.
+You should see a green header ("0 errors") with a per-pass summary. The Leavenworth fixture is clean by construction — no ERRORs.
 
-In a non-notebook context:
+![Validation report card for the Leavenworth fixture](../assets/screenshots/leavenworth-validation-report.png){ .screenshot }
+*Validation report card. Zero ERRORs, with the four passes (structural / schema / FK / sync-state) summarised across 25 tables.*
+
+In a non-notebook context, drop down to the text representation:
 
 ```python
 print(f"{report.spec_version}: {len(report.issues)} issues")
@@ -121,9 +134,9 @@ for issue in report.issues[:5]:
     print(f"  {issue.severity.value:9} {issue.code:30} {issue.message[:60]}")
 ```
 
-### 4. Run quality + display
+### 4. Run quality and display
 
-The data-quality pack flags things the spec is silent on but every real network has — disconnected components, lane-count mismatches, high speeds on residential facilities, near-duplicate nodes.
+The data-quality pack flags things the spec is silent on but every real network has — disconnected components, lane-count mismatches, high speeds on residential facilities, near-duplicate nodes. Run it the same way as validation; the result has its own `_repr_html_`.
 
 ```python
 from datagrove.quality import run_quality
@@ -132,18 +145,21 @@ qreport = run_quality(net)
 qreport  # _repr_html_ renders severity-grouped findings
 ```
 
-You should see a card with WARNING / INFO findings (no ERRORs). Leavenworth's tertiary streets carry posted speeds in the 25-30 mph range with `facility_type=residential`, which triggers `quality.high_speed_residential` if you've configured a low threshold — useful for seeing what a real finding looks like.
+You should see a card with WARNING / INFO findings (no ERRORs). Leavenworth's tertiary streets carry posted speeds in the 25-30 mph range with `facility_type=residential`, which trips `quality.high_speed_residential` when configured with a low threshold — useful for seeing what a real finding looks like.
 
-To see one in detail:
+![Quality report card for the Leavenworth fixture](../assets/screenshots/leavenworth-quality-report.png){ .screenshot }
+*Quality report card. Severity-grouped findings; the residential-speed rule fires on a handful of tertiary streets.*
+
+To see the top findings in detail, iterate over `qreport.issues`:
 
 ```python
 for issue in qreport.issues[:3]:
     print(f"  {issue.severity.value:9} {issue.code:35} {issue.message}")
 ```
 
-### 5. Simplify geometry + render before/after
+### 5. Simplify geometry and render before/after
 
-The `simplify_geometry` op in `gmnspy.clean` removes redundant vertices from link geometries. Wrap it in a `Session` so you can roll back:
+The `simplify_geometry` op in `gmnspy.clean` removes redundant vertices from link geometries. Wrap it in a `Session` so the edit can be rolled back atomically.
 
 ```python
 from datagrove.editing import Session
@@ -154,9 +170,12 @@ with Session(net) as s:
     edit  # in a notebook, _repr_html_ shows the diff (vertices removed per link)
 ```
 
-You should see a diff card listing the number of vertices removed per affected link. `mode="redundant_only"` removes only colinear vertices and is loss-free; `mode="douglas_peucker"` is the lossy alternative with an explicit tolerance.
+You should see an `EditResult` diff card listing the number of vertices removed per affected link. `mode="redundant_only"` removes only colinear vertices and is loss-free; `mode="douglas_peucker"` is the lossy alternative with an explicit tolerance.
 
-To visualise before/after, snapshot the geometry before opening the session and overlay both on one map:
+![EditResult diff card for the simplify-geometry edit](../assets/screenshots/leavenworth-simplify-edit-result.png){ .screenshot }
+*EditResult diff card. Per-link vertex counts before / after, with a summary of links touched and vertices removed.*
+
+To visualise before-and-after on one map, snapshot the geometry before opening the session, then overlay both:
 
 ```python
 links_before = links[["link_id", "shape"]].copy()
@@ -179,15 +198,17 @@ m
 
 Grey underneath = before; red on top = after. On Leavenworth most links don't change (the OSM source is already minimal), but a handful of curved tertiary links visibly simplify.
 
-To restore the original state:
+To restore the original state, roll the session back:
 
 ```python
 s.rollback()
 ```
 
-The session's chronological log reverses every edit atomically — the network returns to byte-identical to step 1.
+The session's chronological log reverses every edit atomically — the network returns byte-identical to step 1.
 
 ### 6. Build a scope from a single node and render
+
+`from_node` builds a network-distance-bounded subgraph around a seed node. The 200 m buffer below is Dijkstra-bounded along the routable graph — links that are spatially close but only reachable via long detours fall outside.
 
 ```python
 from gmnspy.scope import from_node
@@ -196,9 +217,9 @@ scoped = from_node(net, node_id=1, network_buffer="200m").apply()
 print(f"scoped: {scoped.links.count()} links, {scoped.nodes.count()} nodes")
 ```
 
-That's a 200 m **network-distance** (Dijkstra-bounded) buffer around node 1, with every other table — `lane`, `link_tod`, `movement`, etc. — pre-filtered by FK chain.
+Every related table (`lane`, `link_tod`, `movement`, signal tables) is pre-filtered by FK chain, so the result is a self-consistent GMNS network you can write back out.
 
-Render it side-by-side with the original:
+Render the scope side-by-side with the original to see the contrast — full network as grey context, scoped subgraph highlighted.
 
 ```python
 scoped_links = scoped.links.to_pandas().join(geoms[["geometry"]], on="geometry_id")
@@ -216,7 +237,47 @@ for shape in scoped_links["shape"]:
 m
 ```
 
-You should see a small green subgraph centred on one intersection, with the rest of the network greyed out as context. The scope respects the routable graph — links reachable only via long detours fall outside the 200 m buffer even if they're spatially close.
+You should see a small green subgraph centred on one intersection, with the rest of the network greyed out as context.
+
+![Scoped subgraph rendered next to the full Leavenworth network](../assets/screenshots/leavenworth-scoped-map.png){ .screenshot }
+*Scope visualisation. The 200 m network-distance buffer around node 1 highlighted in green, full network in grey context. Long-detour links are excluded even when spatially nearby.*
+
+## Variations you might try
+
+Each accordion below is a one-line tweak that shows off a different facet of the toolkit. Pick whichever matches what you want to learn next.
+
+???+ note "Try a different fixture or your own network"
+    The bundled fixture is Leavenworth. Point `Network.from_source` at any GMNS package on disk or in cloud storage to repeat the tour with your own data — every step above is fixture-agnostic.
+
+    ```python
+    net = Network.from_source("./my-network/")
+    net = Network.from_source("s3://my-bucket/network.parquet/")
+    ```
+
+??? note "Switch to the pandas engine for eager evaluation"
+    The default ibis + DuckDB engine is lazy. Switch to pandas if you'd rather have every table materialised up-front (handy for small fixtures where you'll touch every row).
+
+    ```python
+    from datagrove.engines.pandas_engine import PandasEngine
+
+    net = Network.from_source(leavenworth.csv_dir(), engine=PandasEngine())
+    ```
+
+??? note "Configure a custom quality threshold"
+    Override the `quality.high_speed_residential` threshold (default is conservative). Tightening it surfaces more findings on a network with mixed posted speeds.
+
+    ```python
+    from datagrove.quality import RuleConfig, run_quality
+
+    qreport = run_quality(
+        net,
+        config={
+            "quality.high_speed_residential": RuleConfig(
+                thresholds={"speed_limit_mph": 30.0}
+            )
+        },
+    )
+    ```
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Applies the v2 docs patterns from the foundation PR to the four pages users hit first:

- **`docs/gmnspy/quickstart.md`** (rewritten, 211 lines) — prose-before-code on every step, accordion-style "Common variations" replacing the old table, per-step "Outputs" sub-sections with screenshot placeholders, concrete `--json` explanation with a `jq` example, all fences tagged.
- **`docs/datagrove/quickstart.md`** (new, 176 lines, replacing the foundation stub) — generic Frictionless workflow using `datagrove.Package` (not `gmnspy.Network`), with explicit `spec=` for CSV-only fixtures, spatial scope via `from_bbox`, accordions for engine / S3 / partial-load / spec-URL variations, and pitfalls covering the credential cascade and lazy vs eager engines.
- **`docs/gmnspy/visual-tour.md`** (rewritten, 287 lines) — prose lead on every code block, screenshot placeholders at every "you should see" moment (6 placeholders), tagged fences, closing "Variations you might try" accordion section.
- **`docs/gmnspy/what-is-gmns.md`** (audit only, 94 lines, no edits) — fences already tagged (one `mermaid` block), all cross-links resolve, and the "How it relates to..." subsections carry too much paragraph-per-target rich text to convert to cards without losing density. Left as-is per brief.

## Conventions applied

- Lead every code block with 1-3 sentences of prose explaining the *why* before showing the *what*.
- Convert "Common variations" tables into `???+ note` / `??? note` accordion stacks (first expanded, rest collapsed).
- Embed `![alt](../assets/screenshots/*.png){ .screenshot }` placeholders at every step where the output is visual; captions describe what the reader will see.
- Expand `--json` explanation from a one-line aside to a concrete worked example with `jq`.
- Tag every fence with its language (`python`, `bash`, `text`, `mermaid`).
- Frame the datagrove page as "any Frictionless package" even when using Leavenworth as the demo fixture (avoid coupling the generic engine docs to GMNS).

## Deferred

- Generating the actual screenshot PNGs (task #18).
- Cookbook recipe rewrites (different agent in this wave).
- Concept page rewrites other than the lightly-audited `what-is-gmns.md` (different agent).

## Test plan

- [x] `uv run mkdocs build` — succeeds; 10 new warnings are all intentional screenshot placeholders (target #18 generates the PNGs). Foundation baseline of 5 unrelated warnings unchanged.
- [x] `uv run pytest` — 831 passed, 63 skipped, 0 failed.
- [ ] Visual review of rendered pages once a docs preview is up.

Base: `feat/docs-v2-foundation` (NOT `refactor/v1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)