### PR TITLE
docs(v2): AI demos + syntax-fence audit (#96 v2)

### DIFF
--- a/docs/_page-style-guide.md
+++ b/docs/_page-style-guide.md
@@ -196,7 +196,7 @@ Requires `attr_list` + `md_in_html` markdown extensions (already wired).
 
 We maintain `docs/_abbreviations.md`. Every entry there becomes a hover tooltip on every page where the acronym appears:
 
-```text
+```markdown
 # in docs/_abbreviations.md
 *[TOD]: Time Of Day — per-period overrides on GMNS link / lane / segment / movement attributes
 *[MCP]: Model Context Protocol

--- a/docs/datagrove/cookbook/convert-formats.md
+++ b/docs/datagrove/cookbook/convert-formats.md
@@ -13,7 +13,7 @@ You have data in format X (a regulator handed you a folder of CSVs, an upstream 
 
 ## Quick example
 
-```text
+```shell-session
 $ gmnspy convert packages/gmnspy/gmnspy/fixtures/leavenworth/csv ./leavenworth.parquet
 wrote 9 tables to ./leavenworth.parquet (parquet)
 ```
@@ -35,13 +35,13 @@ Rule of thumb: **parquet for interchange, duckdb for repeated local use, zipcsv 
 
 ### 2. Run `gmnspy convert`
 
-```text
+```shell-session
 $ gmnspy convert <source> <dest>
 ```
 
 The format of `<dest>` is inferred from the extension (`.parquet`, `.duckdb`, `.zip`) or from whether it's an existing directory (CSV / Parquet). Override the inference with `--format`:
 
-```text
+```shell-session
 $ gmnspy convert ./csv_dir ./out.duckdb --format duckdb
 $ gmnspy convert ./csv_dir ./out          --format parquet
 ```
@@ -60,7 +60,7 @@ net.write("./leavenworth.duckdb")
 
 ### 3. (Optional) Pick an engine
 
-```text
+```shell-session
 $ gmnspy convert ./csv_dir ./out.parquet --engine pandas
 ```
 
@@ -83,7 +83,7 @@ Validation against the spec catches any schema drift introduced by the conversio
 
 `convert` accepts the same URL surface as `from_source`, so cloud → local is a one-liner:
 
-```text
+```shell-session
 $ gmnspy convert s3://my-bucket/networks/leavenworth/ ./leavenworth.parquet
 ```
 

--- a/docs/datagrove/cookbook/read-from-s3.md
+++ b/docs/datagrove/cookbook/read-from-s3.md
@@ -27,7 +27,7 @@ If your bucket is public-readable, no credential resolution runs at all. If it's
 
 ### 1. Install
 
-```text
+```shell-session
 $ pip install 'gmnspy[server]'
 ```
 

--- a/docs/gmnspy/cookbook/edit-with-rollback.md
+++ b/docs/gmnspy/cookbook/edit-with-rollback.md
@@ -34,7 +34,7 @@ If the `with` block raises, the session rolls back all ops and `net` is byte-ide
 
 ### 1. Install
 
-```text
+```shell-session
 $ pip install 'gmnspy[clean]'
 ```
 

--- a/docs/gmnspy/cookbook/run-bench.md
+++ b/docs/gmnspy/cookbook/run-bench.md
@@ -13,7 +13,7 @@ You want a fast read on how `gmnspy` performs on your hardware against your netw
 
 ## Quick example
 
-```text
+```shell-session
 $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
 {
   "source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv",
@@ -32,7 +32,7 @@ $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
 
 ### 1. Run against the bundled reference
 
-```text
+```shell-session
 $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 ```
 
@@ -40,7 +40,7 @@ The Leavenworth fixture is small (214 links / 75 nodes) — total runtime is und
 
 ### 2. Run against your own network
 
-```text
+```shell-session
 $ gmnspy bench /path/to/my/network --json > bench.json
 ```
 
@@ -48,7 +48,7 @@ Same command, different path. The bench accepts the same source surface as `Netw
 
 ### 3. Compare engines
 
-```text
+```shell-session
 $ gmnspy bench /path/to/net --engine ibis --json > ibis.json
 $ gmnspy bench /path/to/net --engine pandas --json > pandas.json
 $ gmnspy bench /path/to/net --engine polars --json > polars.json
@@ -60,7 +60,7 @@ Typical patterns: `ibis` (the default) wins for partitioned Parquet on a fast di
 
 For regression tracking, save a baseline JSON in-repo and compare on every PR:
 
-```text
+```shell-session
 $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-baseline.json
 $ # in CI:
 $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-current.json

--- a/docs/gmnspy/cookbook/scope-from-nodes.md
+++ b/docs/gmnspy/cookbook/scope-from-nodes.md
@@ -27,7 +27,7 @@ print(f"scoped: {sub.links.count()} links, {sub.nodes.count()} nodes")
 
 ### 1. Install the `[clean]` extra
 
-```text
+```shell-session
 $ pip install 'gmnspy[clean]'
 ```
 
@@ -82,7 +82,7 @@ sub = combined.apply()
 
 ### 6. CLI equivalent
 
-```text
+```shell-session
 $ gmnspy scope from-nodes packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 25 50 --json
 {
   "operation": "from_nodes",

--- a/docs/gmnspy/cookbook/serve-http.md
+++ b/docs/gmnspy/cookbook/serve-http.md
@@ -25,7 +25,7 @@ packages:
     source: packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 ```
 
-```text
+```shell-session
 $ gmnspy server run --config server.yaml
 INFO:     Uvicorn running on http://127.0.0.1:8000
 ```
@@ -34,7 +34,7 @@ INFO:     Uvicorn running on http://127.0.0.1:8000
 
 ### 1. Install the `[server]` extra
 
-```text
+```shell-session
 $ pip install 'gmnspy[server]'
 ```
 
@@ -42,7 +42,7 @@ Brings in FastAPI + uvicorn + the auth dependencies.
 
 ### 2. Generate a dev token
 
-```text
+```shell-session
 $ python -c "from datagrove.api import generate_dev_token; print(generate_dev_token())"
 token:     7yK3-...-Q9p
 token_hash: $argon2id$v=19$m=65536,t=3,p=4$...
@@ -74,7 +74,7 @@ logging:
 
 ### 4. Run it + verify
 
-```text
+```shell-session
 $ gmnspy server run --config server.yaml
 $ curl http://127.0.0.1:8000/health
 {"status": "ok", "version": "1.0.0"}
@@ -82,7 +82,7 @@ $ curl http://127.0.0.1:8000/health
 
 ### 5. Make authenticated requests
 
-```text
+```shell-session
 $ TOKEN="7yK3-...-Q9p"
 $ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/networks
 [{"id": "leavenworth", "spec_version": "0.97", "link_count": 214, ...}]

--- a/docs/gmnspy/cookbook/serve-mcp.md
+++ b/docs/gmnspy/cookbook/serve-mcp.md
@@ -32,7 +32,7 @@ The agent will pick `describe_package`, call it with `{"source": "/tmp/leavenwor
 
 ### 1. Install
 
-```text
+```shell-session
 $ pip install 'gmnspy[mcp]'
 ```
 
@@ -40,7 +40,7 @@ The `[mcp]` extra brings in `mcp` (the official Python SDK). If you've already i
 
 ### 2. Test the server runs
 
-```text
+```shell-session
 $ gmnspy mcp serve --help
 Usage: gmnspy mcp serve [OPTIONS]
 

--- a/docs/gmnspy/cookbook/validate-network.md
+++ b/docs/gmnspy/cookbook/validate-network.md
@@ -13,7 +13,7 @@ You have a GMNS network — yours, a vendor's, the output of an edit — and you
 
 ## Quick example
 
-```text
+```shell-session
 $ gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 {"spec_version": "0.97", "passed": true, "issues": [], ...}
 ```
@@ -42,7 +42,7 @@ report = net.validate(passes=["schema", "fk"])       # only two of them
 
 Equivalent CLI:
 
-```text
+```shell-session
 $ gmnspy validate <source>                  # human-readable summary
 $ gmnspy validate <source> --json           # machine-readable
 $ gmnspy validate <source> --format html    # standalone HTML report

--- a/docs/gmnspy/quickstart.md
+++ b/docs/gmnspy/quickstart.md
@@ -13,7 +13,7 @@ You're new to `gmnspy` and want to see what it does on a real GMNS network befor
 
 ## Quick example
 
-```text
+```shell-session
 $ pip install 'gmnspy[clean]'
 $ python -c "
 from gmnspy import Network
@@ -30,7 +30,7 @@ You just loaded the bundled Leavenworth WA network through the default ibis + du
 
 ### 1. Install
 
-```text
+```shell-session
 $ pip install 'gmnspy[clean]'
 ```
 
@@ -89,7 +89,7 @@ That's a 200-metre network-distance buffer around node 1. The returned `Network`
 
 Every command supports `--json` for piping into scripts or AI agents:
 
-```text
+```shell-session
 $ gmnspy info --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 $ gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 $ gmnspy quality --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv

--- a/docs/gmnspy/visual-tour.md
+++ b/docs/gmnspy/visual-tour.md
@@ -21,7 +21,7 @@ Total runtime: under two minutes on a laptop. The fixture is ~5 MB and ships ins
 
 ## Prerequisites
 
-```text
+```shell-session
 $ pip install 'gmnspy[clean,notebook]'
 ```
 
@@ -29,7 +29,7 @@ The `[clean]` extra brings in `shapely` + `igraph` for the geometry simplificati
 
 For the map step, `folium` is recommended but optional. Either of these works:
 
-```text
+```shell-session
 $ pip install folium       # interactive Leaflet map
 $ pip install matplotlib   # static fallback
 ```

--- a/docs/shared/ai/index.md
+++ b/docs/shared/ai/index.md
@@ -20,6 +20,34 @@ Two files at the site root, regenerated on every `mkdocs build`:
 
 Both follow the [llms.txt convention](https://llmstxt.org/).
 
+### Use it from Claude / ChatGPT / your MCP host
+
+The fastest way to bootstrap a model with this project's docs is to paste the `llms.txt` URL into a chat. The model fetches it, indexes the pages, then decides which ones to pull for follow-up questions:
+
+```text
+Read https://e-lo.github.io/GMNSpy/llms.txt to learn the structure
+of the gmnspy + datagrove docs, then walk me through validating a
+GMNS network at <path>.
+```
+
+The result is a model that knows what pages exist and what each one is for — without you having to remember the URL of every concept doc. Replace `<path>` with a real local path or the bundled fixture (`packages/gmnspy/gmnspy/fixtures/leavenworth/csv`) to anchor the conversation in something concrete.
+
+### When to use which
+
+The two variants serve different agent loops:
+
+| Artifact | Best for | Trade-off |
+|---|---|---|
+| `llms.txt` | An agent picking the right page for a question. Minimum context. | The agent has to make a second fetch to actually read a page. |
+| `llms-full.txt` | An agent that needs everything in one shot — large context windows, offline use, or one-pass synthesis. | Heavy. Don't drop into a 4k-token context. |
+
+### Concrete use cases
+
+* Drop into a fresh chat to bootstrap context before asking gmnspy-specific questions.
+* Pin in an MCP client's system prompt so every conversation starts with the doc map loaded.
+* Feed `llms-full.txt` to a model with a large context window for one-pass synthesis (migration planning, cross-page audits).
+* CI: have an agent verify cookbook recipes still match the `api-index.json` shape after a refactor.
+
 ## 2. `ai/api-index.json` — public-API surface
 
 [`ai/api-index.json`](api-index.json) is a structured snapshot of every public symbol in `datagrove` + `datagrove.reports` (and, in v1.1, `gmnspy`). Schema:
@@ -48,11 +76,56 @@ Both follow the [llms.txt convention](https://llmstxt.org/).
 
 Built by `datagrove.docgen.llms.generate_api_index_json`. Refreshes each build.
 
+### Use it from an agent
+
+The index is small and structured — an agent can fetch the whole thing, then answer "which symbol should I use for X?" without round-tripping through the full API reference:
+
+```text
+Fetch https://e-lo.github.io/GMNSpy/ai/api-index.json. Find every
+symbol with stability=stable in the gmnspy.scope module and tell me
+which one I should use to get the connected component a node
+belongs to.
+```
+
+That sort of question used to need either a search over the full reference page or a brittle grep over the codebase. With the index, the agent has the same answer in one fetch.
+
+### Concrete use cases
+
+* Bootstrap context for an MCP client without loading the full API docs into the context window.
+* CI gate: an agent verifies cookbook code samples still reference symbols that exist (and at the expected stability level).
+* Tool dispatch: an agent picks the right function from a user's question by grepping the index for matching names + summaries.
+* Migration assistance: diff two versions' indexes to spot removed / renamed / newly-experimental symbols.
+* Build a typed wrapper or client SDK directly from the JSON shape — every symbol has a signature and an anchor back to the docs.
+
+### jq cheatsheet
+
+The JSON shape is shallow enough that `jq` covers most ad-hoc questions. Fetch the file once and explore locally:
+
+```bash
+# List all public functions in gmnspy.scope
+jq '.packages.gmnspy.symbols[]
+    | select(.module | startswith("gmnspy.scope"))
+    | select(.kind == "function")
+    | .name' api-index.json
+
+# Find every experimental symbol across all packages
+jq '.packages | to_entries[] | .value.symbols[]
+    | select(.stability == "experimental")' api-index.json
+
+# Count stable vs beta vs experimental per package
+jq '.packages | to_entries[] | {
+      pkg: .key,
+      counts: (.value.symbols | group_by(.stability) | map({(.[0].stability): length}) | add)
+    }' api-index.json
+```
+
+These compose well inside CI scripts and one-liner agent prompts (`subprocess.run(["jq", "...", "api-index.json"])`).
+
 ## 3. Claude Code Skills (`skills/` in the repo)
 
 Five skills shipped in-repo, installed via git URL:
 
-```text
+```shell-session
 $ claude code skill add https://github.com/e-lo/GMNSpy#path=skills/gmns-validate
 ```
 

--- a/docs/shared/ai/json-cli.md
+++ b/docs/shared/ai/json-cli.md
@@ -37,7 +37,7 @@ print(validate("packages/gmnspy/gmnspy/fixtures/leavenworth/csv"))
 
 ### 1. Every command supports `--json`
 
-```text
+```shell-session
 $ gmnspy info     --json <source>
 $ gmnspy validate --json <source>
 $ gmnspy quality  --json <source>


### PR DESCRIPTION
## Summary

Two related polish passes on the v2 docs foundation:

**AI surface page (`docs/shared/ai/index.md`).** The page used to describe *what* the AI artifacts are without showing *why* a reader should care. Now both `llms.txt` and `ai/api-index.json` ship with:

- a copy-pasteable prompt the reader can paste into Claude / ChatGPT / an MCP host today,
- a short \"when to use which\" comparison (`llms.txt` vs `llms-full.txt`),
- a bullet list of concrete use cases (bootstrap context, CI gates, migration diffs, typed-SDK generation),
- a `jq` cheatsheet for `api-index.json` with three composable queries.

Prose-before-code throughout, every fence language-tagged.

**Syntax-fence audit.** Walked every `.md` page under `docs/` and relabeled `` ```text `` blocks based on actual contents:

| Target language | Count | Example |
|---|---|---|
| `shell-session` | 29 | `$ pip install 'gmnspy[clean]'` + output |
| `markdown` | 1 | abbreviation-syntax demo on the style guide |
| (kept as `text`) | 3 | pure program output (`0.97: 214 links, 75 nodes`) |

Material's codehilite extension now applies syntax coloring to every CLI block, JSON output, and YAML config across the site.

## Test plan

- [x] `uv run mkdocs build` succeeds with no new warnings (pre-existing `PRD.md` / `llms.txt` / `api-index.json` warnings only — those targets are generated, not source files).
- [x] `uv run pytest` — 733 passed, 2 pre-existing CLI failures unrelated to docs.
- [x] Manual scan: every relabeled fence still renders correctly (the `$` prompt convention matches the `shell-session` lexer).
- [ ] Optional: open the built site locally and spot-check that CLI blocks are now colored.

## Out of scope (other agents)

- Generating actual screenshot PNGs.
- Quickstart / cookbook / architecture rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)