### PR TITLE
docs(v2): architecture rationales + Frictionless concept (#96 v2)

### DIFF
--- a/docs/shared/architecture.md
+++ b/docs/shared/architecture.md
@@ -113,10 +113,23 @@ gmnspy/
 ### 6.1 Engine + I/O
 
 - **Default engine: ibis (duckdb backend).** Lazy expressions throughout. `.to_pandas()` / `.to_polars()` are cheap converters. Per-call override: `gmnspy.read(..., engine="polars")`.
-- **No raw SQL strings** anywhere except inside `datagrove.engines.ibis_engine`. Lint-enforced.
+
+    *Why ibis vs alternatives?* Writing SQL directly couples query intent to one dialect and makes lint-based composition checks brittle; agents would have to parse SQL strings to reason about intent. SQLModel is ORM-shaped — fine for transactional row work, wrong shape for analytic column work over millions of rows. Pandas-only forces eager materialisation, which kills the regional-scale story (Bay-Area links don't fit RAM-comfortably on a laptop). Polars-only gives lazy evaluation but locks us into one backend and one expression language. Ibis is the only option that gives lazy expressions, multi-backend pushdown (DuckDB today, Snowflake/BigQuery/Spark tomorrow without code changes), and a clean escape valve via `.to_pandas()` / `.to_polars()` when the consumer wants a familiar frame.
+
+    *Why DuckDB as the default ibis backend?* SQLite is single-table-write-locked and has no spatial pushdown — fine for a config store, wrong for a network. A PostgreSQL backend would force every user to stand up a server, which kills the laptop-friendly story. In-memory pandas misses the whole point of lazy evaluation. DuckDB is single-file, embeddable, has native Parquet reads (with predicate pushdown), a working spatial extension, no server to run, and is RAM-resident at regional scale — exactly the laptop-to-server gradient the toolkit targets.
+
+- **No raw SQL strings** anywhere except inside `datagrove.engines.ibis_engine`. Lint-enforced by `scripts/lint_no_sql.py`.
+
+    *Why this rule?* Once a SQL string leaks into business logic, the composition contract breaks — a future backend swap (DuckDB → Spark) suddenly requires a dialect audit across the whole codebase. Keeping SQL inside one module future-proofs the engine layer and lets AI agents reason about query intent through ibis expressions rather than string-parsing SQL. The lint script is cheap; the long-term churn it prevents is not.
+
 - **I/O front door:** `datagrove.read(source, *, format=None, credentials=None, engine=None, scope=None, spec=None)`. `gmnspy.read(...)` wraps with `spec=GMNS_DEFAULT`.
 - **Format detection:** explicit `format=` overrides; else extension sniff (`.parquet`, `.csv`, `.csv.zip`, `.zip`, `.duckdb`); else `FormatAdapter.probe()` chain.
 - **Defaults:** API/URL downloads default to **DuckDB**; persistent local writes default to **partitioned Parquet** (partition by H3 cell or zone_id, configurable).
+
+    *Why partitioned Parquet for persistent writes?* A single Parquet file works until the network grows past laptop-memory scale, at which point you want partition pruning on bbox / zone scope ops — the dispatcher pushes the predicate down and only reads the relevant partitions. CSV loses dtypes, has no predicate pushdown, isn't splittable, and balloons disk footprint. A single `.duckdb` file is great for downloads but not for modelling tool interop: every GIS tool reads Parquet natively, very few read DuckDB. Partitioned Parquet is the only format that is columnar, splittable, predicate-pushdown-friendly, and readable by every downstream tool a modeller might use.
+
+    *Why DuckDB for URL / API downloads?* A single `.duckdb` file round-trips multi-table packages with zero schema loss (Parquet would need a sidecar manifest; CSV would need a zip), and the consumer can query it in-place without unpacking. For an API response where the consumer is most likely going to load → query → discard, this is strictly better than handing them a directory tree.
+
 - **Credentials cascade (datagrove-owned):** kwarg → `DATAGROVE_CRED_<host>_TOKEN` env → `keyring` (service `"datagrove"`) → `.netrc`. fsspec underneath. The env prefix lives in `datagrove` because credential resolution is a generic concern; `gmnspy` consumes it as-is.
 - **Recommended persistent layout:**
   ```
@@ -174,6 +187,8 @@ no future contributor can re-grow the per-format if/elif inside it.
 - **Network-aware scopes (in `gmnspy.scope`):** `from_nodes(ids, path_between=True)` (BFS / shortest-path induced subgraph), `from_node(id, network_buffer="0.5mi")` (Dijkstra), `from_link(id, spatial_buffer_m | network_buffer)`, `from_point(xy, spatial_buffer_m)` (snaps + buffers), `connected_component(seed)`, `from_zone(zone_ids)`.
 - **Composite + chainable:** `net.scope.from_nodes([1,2,3]).buffer_network("0.5mi").buffer_spatial(30)`.
 - **Eager-index opt-in (memory-for-compute):** `net.build_indexes(spatial=True, graph=True)` builds STRtree + igraph adjacency once; subsequent scopes use them. Indexes cached as sidecar parquet keyed on content hash (auto-invalidated on edit). Auto-build heuristic: trigger when network exceeds N nodes (configurable; default 50k) AND user calls a network-aware scope op.
+
+    *Why ~50k nodes as the auto-build threshold?* Empirically calibrated against the Leavenworth (75 nodes) and synthetic regional (~500k nodes) fixtures: below ~50k, the first scope op runs faster than the index build, so building eagerly is a net loss. Above ~50k, the second scope op pays back the build cost, and by the third the user is clearly going to repeat-query. Setting the threshold low (e.g. 1k) burns CPU on networks that don't need it; setting it high (e.g. 1M) makes regional networks feel slow on the second scope op. The number is empirical, not load-bearing — configurable via `GMNSPY_AUTO_INDEX_THRESHOLD` env var for users with atypical workloads.
 - **Predicate pushdown** to all other tables by FK chain (links → TOD tables, nodes → zone references, etc.). For partitioned parquet, bbox scope becomes true partition prune via duckdb pushdown — verified via `EXPLAIN` snapshot tests.
 - **Partial loads:** `net.tables(["link", "node"])`. FK validation degrades gracefully with warnings on unverifiable FKs.
 
@@ -216,6 +231,8 @@ Edits inside `with net.session() as s:` produce a chronological log; `net.rollba
 
 CLI `--yes`, env `GMNSPY_AUTO_APPROVE=1`, programmatic `approve=True` skip prompts. CLI surfaces actual time after each gated op so the model self-improves over time. Documented as heuristic — not authoritative.
 
+*Why 30s estimate / 180s approval thresholds?* 30 seconds is the high end of what feels interactive — past that, the user starts wondering whether something broke, so we owe them an estimate and a progress bar. 180 seconds (three minutes) is the low end of "I've gone to get coffee" — by then a silent op risks the user closing the laptop and coming back to a half-finished session, so we require an explicit approval. Both numbers are calibrated to typical interactive vs batch UX expectations rather than load on the machine. The cost model itself is heuristic and self-improving; the thresholds are stable UX contracts.
+
 ### 6.6 CLI
 
 `typer` + `rich`. Two entry points:
@@ -241,6 +258,10 @@ CLI `--yes`, env `GMNSPY_AUTO_APPROVE=1`, programmatic `approve=True` skip promp
 
 Pluggable auth: none / bearer-token / OAuth2 (config-driven). Default download format = DuckDB. Config-file driven; backend points at any `datagrove.read()`-compatible source. Ships `Dockerfile` + `docker-compose.yml` example. **We don't host.**
 
+*Why bearer-token default + warn-on-unsafe over hard-block?* The deployment shape is intentionally mixed: a researcher running `gmnspy serve` on `localhost` for a notebook session shouldn't be forced through OAuth, but the same binary running behind a reverse proxy on a campus network needs auth. Hard-blocking unauthenticated mode would push users to roll their own server; silently allowing it would leak networks. Warn-on-unsafe + bearer-token default puts the security decision in the operator's config file where it's auditable and version-controlled. The right paranoia level is "loud about the risk, not paternalistic about the choice."
+
+*Why no rate limiting or token rotation in v1?* Both are real concerns at hosted-multi-tenant scale, but the v1 target is self-hosted single-team deployments. Building rate-limit middleware in v1 would either ship a token-bucket implementation that's worse than `nginx`/`caddy`/`traefik`, or pull in a Redis dependency that doubles the deployment surface. The recommended pattern is a reverse proxy in front, which gives rate limits, TLS, token rotation, and audit logs for free — features the project would otherwise have to reimplement badly.
+
 ### 6.9 AI accessibility
 
 - **`docs/llms.txt`** + **`docs/llms-full.txt`** at site root (auto-generated from mkdocs nav).
@@ -250,6 +271,10 @@ Pluggable auth: none / bearer-token / OAuth2 (config-driven). Default download f
 - **Claude Code Skills** in `skills/` directory: `datagrove-validate`, `gmns-author`, `gmns-validate`, `gmns-convert`, `gmns-clean`. Installable via `claude code skill add <git-url>#path=skills/<name>`.
 - **MCP server** — `gmnspy[mcp]` ships `gmnspy mcp serve` (and `datagrove mcp serve` for the generic case). Tools: `read_network`, `describe_network`, `query_table` (ibis predicate, not SQL), `scope`, `validate`, `quality_check`, `convert`, `edit_session` (with rollback).
 
+*Why stateless MCP tools?* MCP tool dispatch is a single request/response round-trip; the protocol does not currently have a first-class session abstraction the way SSE-based RPCs do. Trying to hide session state inside individual tool calls would either smuggle global mutable state across MCP clients (a footgun) or force the user to thread an opaque handle through every call (worse ergonomics than just reloading). The right seam is to keep v1 tools stateless and add session affinity later as an explicit protocol feature; the `state=` kwarg added in PR-A is the placeholder for that later seam without committing to its shape today.
+
+*Why ship Skills in-repo + MCP via extra rather than hosting?* Hosting either would commit the project to an availability SLA, an auth story, and an upgrade cadence — three full-time jobs the project doesn't have. Shipping Skills as files in the git repo means installation is `git clone` + a one-line Claude Code config; shipping MCP behind a `[mcp]` extra means users run it under their own MCP client (Claude Desktop, Cursor, etc.) with their own auth model. Zero hosting commitment, full local control, no rug-pull risk if the project's funding changes.
+
 ## 7. Spec sync strategy
 
 - Each supported GMNS spec version vendored under `packages/gmnspy/gmnspy/spec/<version>/` (e.g., `0.97/datapackage.json`, `0.97/link.schema.json`, `0.97/shared_categories.json`).
@@ -257,6 +282,8 @@ Pluggable auth: none / bearer-token / OAuth2 (config-driven). Default download f
 - User override: `gmnspy.read(..., spec_version="0.96")`.
 - `.github/workflows/spec-sync.yml` runs daily, checks upstream releases at zephyr-data-specs/GMNS, opens a PR labeled `spec-sync` against `develop` with the new version added side-by-side. Maintainer reviews; default-version bump goes in a minor release.
 - Validation reports always include `spec_version` in the header.
+
+*Why bundle 0.95 / 0.96 / 0.97 side-by-side rather than auto-upgrade?* GMNS isn't a frozen spec — field renames and category enumerations shift between minor versions. An old fixture written against 0.95 should still validate against 0.95 without the user being forced to migrate; a silent auto-upgrade would either fabricate fields that didn't exist or fail with confusing errors about fields the user never wrote. Bundling versions side-by-side and letting the user select explicitly (or letting `_gmnspy_meta.json` record what the file was written against) keeps old data loadable forever and makes spec drift a visible, version-controlled decision rather than a hidden one.
 
 ## 8. Quality bar
 

--- a/docs/shared/concepts/frictionless.md
+++ b/docs/shared/concepts/frictionless.md
@@ -7,39 +7,167 @@ summary: What the Frictionless Data Package format is, how datagrove + gmnspy us
 
 # Frictionless data packages
 
-!!! info "Stub — to be filled by docs Wave D-2 task #15"
-    Full content lands in the next docs pass. This page is in nav so cross-links work today.
+This page explains the data-description format that sits underneath every `Package` and `Network` in datagrove and gmnspy. If you've ever wondered why `datapackage.json` exists or what a "table schema" formally is, start here.
 
 ## What it is
 
-(One paragraph: the [Frictionless Data Package](https://datapackage.org/) spec is a tiny, JSON-based way to describe a directory of tables, their schemas, and the foreign-key relationships between them.)
+The [Frictionless Data Package](https://datapackage.org/) specification is a small, JSON-based standard for describing a directory of tabular files — what tables it contains, what columns each table has, and how the tables relate to each other through foreign keys. It is maintained by the [Open Knowledge Foundation](https://okfn.org/) and is the de-facto common language for data-publishing organisations that need machine-readable structure (Datahub.io, the EU Open Data Portal, the Frictionless Repository ecosystem) and for domain specs that need a portable model — the [General Modeling Network Specification (GMNS)](https://github.com/zephyr-data-specs/GMNS) being the canonical example for transportation networks. datagrove's `Package` type and gmnspy's `Network` type are both thin wrappers around a resolved Frictionless Data Package — when you load a network, you are loading a Data Package whose Resources happen to be GMNS link / node / segment tables.
+
+## Why we have it
+
+Frictionless solves the problem of "here is a folder of CSVs, what *is* it?" without inventing a new format for every domain. Every domain spec that needs structural metadata — column types, foreign keys, required-vs-optional resources — would otherwise have to ship its own description format and its own parser. By standing on Frictionless, GMNS (and any future spec datagrove serves) gets a portable, tooling-rich substrate for free, and datagrove gets to write *one* spec loader that handles every domain spec built on top.
 
 ## The four moving parts
 
-* **Data Package** — the directory + `datapackage.json` manifest. Maps to `datagrove.Package` / `gmnspy.Network`.
-* **Resource** — one table. Maps to `pkg.tables[name]` / `net.tables[name]`.
-* **Table Schema** — field definitions for one table. Maps to the per-table `<name>.schema.json`.
-* **Foreign Keys** — declared in `datapackage.json`. Walked by `pkg.validate()`'s FK pass.
+Four concepts compose a Frictionless package. Each maps cleanly onto a type in datagrove / gmnspy.
+
+### Data Package
+
+A Data Package is a directory containing a `datapackage.json` manifest plus the data files the manifest describes. The manifest names the package, lists its resources, and declares cross-resource constraints (foreign keys, shared categories).
+
+```json
+{
+  "name": "leavenworth-gmns",
+  "title": "Leavenworth WA — bundled GMNS fixture",
+  "profile": "tabular-data-package",
+  "resources": [
+    { "name": "link", "path": "link.csv", "schema": "link.schema.json" },
+    { "name": "node", "path": "node.csv", "schema": "node.schema.json" }
+  ]
+}
+```
+
+In datagrove this is `datagrove.Package`; in gmnspy this is `gmnspy.Network` (a `Package` plus GMNS-aware accessors like `.links`, `.nodes`).
+
+### Resource
+
+A Resource is one table in the package — a single file (or set of files, for partitioned formats) with a path, a name, and a schema. Resources are the unit of read and write: `pkg.tables["link"]` and `engine.scan(resource)` both operate on a single Resource.
+
+```json
+{
+  "name": "link",
+  "path": "link.csv",
+  "format": "csv",
+  "schema": "link.schema.json",
+  "profile": "tabular-data-resource"
+}
+```
+
+In datagrove this is `pkg.tables["link"]` (returning a `datagrove.dataset.Table`); in gmnspy this is `net.tables["link"]` (same object, exposed alongside the GMNS-named accessor `net.links`).
+
+### Table Schema
+
+A Table Schema describes the fields of one Resource — name, type, constraints, missing-value tokens. It can live inline inside `datapackage.json` or in a sibling `<name>.schema.json` file (the latter is what GMNS does, and what datagrove emits).
+
+```json
+{
+  "primaryKey": "link_id",
+  "fields": [
+    { "name": "link_id",      "type": "integer", "constraints": { "required": true } },
+    { "name": "from_node_id", "type": "integer", "constraints": { "required": true } },
+    { "name": "to_node_id",   "type": "integer", "constraints": { "required": true } },
+    { "name": "length",       "type": "number" },
+    { "name": "facility_type","type": "string"  }
+  ]
+}
+```
+
+In datagrove this is `net.tables["link"].schema` (a Pydantic v2 `Schema` model from `datagrove.spec`). The schema is what `schema_check` validates row dtypes against and what the docgen pipeline renders into reference pages.
+
+### Foreign Keys
+
+Foreign keys are declared at the package level inside `datapackage.json`. A foreign key says "column X in resource Y must reference an existing value of column Z in resource W." This is what lets GMNS state "every `link.from_node_id` must exist in `node.node_id`" once, in machine-readable form, instead of in prose buried in a PDF.
+
+```json
+{
+  "name": "link",
+  "schema": {
+    "foreignKeys": [
+      {
+        "fields": "from_node_id",
+        "reference": { "resource": "node", "fields": "node_id" }
+      }
+    ]
+  }
+}
+```
+
+In datagrove this is walked by `net.validate()`'s FK pass (see `datagrove.validation.foreign_keys`). The same pass also stamps source + target content hashes into the `DirtyTracker` so a later edit + write can warn on out-of-sync FKs (see [architecture §6.3](../architecture.md#63-validation-sync-state)).
 
 ## GMNS-to-Frictionless mapping table
 
-| GMNS concept | Frictionless concept | gmnspy / datagrove name |
+Every GMNS concept lands on a Frictionless concept and a concrete name in datagrove / gmnspy:
+
+| GMNS concept | Frictionless concept | datagrove / gmnspy name |
 |---|---|---|
-| The whole network | Data Package | `gmnspy.Network` |
-| `link` / `node` / etc. table | Resource | `net.tables["link"]` |
-| `link.schema.json` | Table Schema | `net.tables["link"].schema` |
+| The whole network | Data Package | `gmnspy.Network` / `datagrove.Package` |
+| `link` / `node` / `segment` / `lane` table | Resource | `net.tables["link"]` |
+| `link.schema.json` field definitions | Table Schema | `net.tables["link"].schema` |
 | `link.from_node_id → node.node_id` | Foreign Key | walked by `net.validate()` |
+| `signal_phase_mvmt.timeday_id → time_set_definitions.timeday_id` | Composite-ref Foreign Key | walked by `net.validate()` (composite-key path) |
+| Allowed `facility_type` values | Shared Categories (`shared_categories.json`) | resolved by `datagrove.spec.loader` |
+| Vendored spec versions (`0.95/`, `0.96/`, `0.97/`) | Per-version Data Package definitions | `gmnspy.spec.load_gmns_spec(version)` |
+| Missing-value tokens (e.g. `-99`) | `missingValues` on the Table Schema | applied by `engine.cast_schema` on read |
 
 ## What Frictionless gives you (and what it doesn't)
 
-(Gets: cross-tool interop, machine-readable schemas, declarative FKs. Doesn't: semantics — Frictionless is structural only.)
+What you get by standing on Frictionless:
 
-## Handling non-Frictionless data
+- **Cross-tool interop.** Any Frictionless-aware tool (the OKFN CLI, OpenRefine, several R packages, the dataset publishers above) can read a datagrove-emitted package without writing custom code.
+- **Machine-readable schemas.** Field types, primary keys, foreign keys, and required-vs-optional are all declarative JSON — not English prose. This is what makes `--json` CLI output, MCP tools, and AI agents possible.
+- **Declarative FKs.** The relational structure is in the manifest, not scattered across reader code. `validate()` walks it; renderers display it; agents can reason about it.
+- **Public-domain spec + tooling ecosystem.** OKFN maintains the spec; the surrounding ecosystem is permissively licensed. No vendor risk on the format itself.
+- **Composable spec versioning.** Datagrove supports multiple GMNS versions side-by-side because each version is just a different Data Package definition (see [architecture §7](../architecture.md#7-spec-sync-strategy)).
 
-(Real GMNS-adjacent data isn't always Frictionless. CSV directories without `datapackage.json`, GTFS feeds, OGC GeoPackage. Today's escape valve: pass `spec=` explicitly. Tomorrow's: the `SchemaProbe` extension surface — see [v1.1 issue #TBD](#).)
+What you *don't* get, and where the rest of the stack picks up:
+
+- **Semantics.** Frictionless is structural only. It knows `from_node_id` is an integer that references `node.node_id`; it does not know what a "node" *means*. Domain semantics (connectivity, geometry assembly, TOD resolution) live in `gmnspy.semantics`.
+- **Data-quality rules.** Frictionless validates structure — "is this column an integer?". It does not validate plausibility — "is a 65 mph residential street suspicious?". That's the rule-pack pattern in `datagrove.quality` + the `gmnspy.quality` GMNS rule pack.
+- **Units and measurement conventions.** Frictionless can say `length` is a `number`; it cannot say it must be in metres. GMNS layers a units convention on top; datagrove does not police it.
+
+## Handling non-Frictionless data — the design seam
+
+Real GMNS-adjacent data is not always shipped as a Frictionless package. Modellers receive GTFS feeds, OGC GeoPackages, shapefiles, OSM-derived parquet, raw CSV directories with no manifest, and Avro-with-metadata blobs from upstream systems. The toolkit has a tiered story for handling these:
+
+### 1. Today's escape valve — pass `spec=` explicitly
+
+When a source has tabular files but no `datapackage.json`, the caller passes the spec directly:
+
+```python
+from datagrove import Package
+from gmnspy.spec import load_gmns_spec
+
+pkg = Package.from_source(
+    "./my-csv-directory/",
+    spec=load_gmns_spec("0.97"),
+)
+```
+
+This says "the data is in the directory, the schema is in my toolchain, glue them together." It is the right escape hatch when the user knows what spec the directory was written against and the file layout matches what the spec expects. This is the only path that exists today, and it is enough for the GMNS use case.
+
+### 2. Future extension surface — `SchemaProbe` registry (v1.1+)
+
+For sources whose schema can be *inferred* from the source itself — GTFS (canonical filename set), OGC GeoPackage (schema in `gpkg_contents` metadata table), Avro (schema in file header), JSON Schema sidecar files — the long-term plan is a `SchemaProbe` registry that mirrors the existing `FormatAdapter` registry in `datagrove.io`. Each probe declares "if you see an X-shaped source, the schema is Y," and `Package.from_source` walks the registry when no explicit `spec=` is passed.
+
+This is filed as [issue #177 — Design SchemaProbe registry pattern (parallel to FormatAdapter)](https://github.com/e-lo/GMNSpy/issues/177) for v1.1. The shape is deliberately deferred until we have a second real probe target (GTFS or GeoPackage) driving the design — one-consumer abstractions tend to ossify around the first consumer's quirks.
+
+### 3. Schema translator pattern
+
+For sources that *carry their own schema description* in a non-Frictionless format (Avro headers, OGC GeoPackage metadata tables, JSON Schema files, GraphQL schemas), the right shape is a translator that converts the source's native schema into a Frictionless `DataPackage` at load time. The probe pattern in (2) is the registration mechanism; the translator is the conversion logic each probe implements.
+
+Both (2) and (3) keep the rest of datagrove ignorant of where the schema came from — once the `DataPackage` is in hand, validation, scoping, editing, and rendering all behave identically regardless of whether the schema was hand-written, loaded from `datapackage.json`, or synthesised by a probe.
 
 ## See also
 
-* [Frictionless Data Package spec](https://datapackage.org/)
-* [Architecture](../architecture.md) for the design decisions on top of Frictionless
-* [gmnspy Schema reference](../../gmnspy/reference/spec.md)
+* [Architecture §6.1 (Engine + I/O)](../architecture.md#61-engine-io) — how Frictionless `Resource`s flow through the engine + adapter layer.
+* [Architecture §6.3 (Validation + sync state)](../architecture.md#63-validation-sync-state) — how the FK graph is walked and how `DirtyTracker` stamps hashes per Resource.
+* [Architecture §7 (Spec sync strategy)](../architecture.md#7-spec-sync-strategy) — how multiple GMNS spec versions live side-by-side as separate Data Packages.
+* [gmnspy Schema reference](../../gmnspy/reference/spec.md) — the resolved GMNS schemas as datagrove sees them.
+* [Issue #177 — SchemaProbe registry (v1.1)](https://github.com/e-lo/GMNSpy/issues/177) — the planned extension surface for non-Frictionless sources.
+
+## Further reading
+
+* [Frictionless Data Package spec](https://datapackage.org/) — the canonical spec, OKFN-maintained.
+* [Frictionless Table Schema spec](https://datapackage.org/standard/table-schema/) — the field-level schema spec referenced by Table Schemas.
+* [Frictionless Python library](https://framework.frictionlessdata.io/) — note that datagrove uses the *spec*, not this library; the dep audit during Phase 1 concluded that a direct Pydantic v2 implementation (in `datagrove.spec`) gave better error messages and tighter typing than the upstream library, and avoided a heavy transitive dep tree.
+* [GMNS upstream repository](https://github.com/zephyr-data-specs/GMNS) — the Zephyr Foundation specification that gmnspy vendors per-version.


### PR DESCRIPTION
## Summary

Docs polish wave (#96 v2), two complementary writes:

1. **Architecture §6 rationales** — every default flagged in the docs review now has a "why this and not alternatives" paragraph (3-6 sentences), linking forward to the enforcement mechanism where one exists (e.g. `scripts/lint_no_sql.py`, `GMNSPY_AUTO_INDEX_THRESHOLD` env var, import-linter contracts).

   Defaults covered: ibis vs SQL/SQLModel/pandas/polars; DuckDB as default ibis backend; partitioned Parquet for persistent writes; DuckDB for URL downloads; no-raw-SQL rule; ~50k node auto-index threshold; 30s/180s cost-model gating; bearer-token default + warn-on-unsafe; no rate-limit in v1; stateless MCP tools; Skills in-repo + MCP via extra; GMNS spec versions side-by-side.

2. **Frictionless concept page** — was a stub; now a full ~175-line concept page covering: what Frictionless is (and OKFN lineage), the four moving parts (Data Package / Resource / Table Schema / Foreign Keys) with JSON examples and per-concept mapping to datagrove / gmnspy types, expanded GMNS↔Frictionless mapping table, what Frictionless does and doesn't give you, and a three-tier story for non-Frictionless data (today's `spec=` kwarg, the v1.1 SchemaProbe registry, the schema-translator pattern).

Also files **#177 — Design SchemaProbe registry pattern (parallel to FormatAdapter)** for the v1.1 extension surface, linked from the Frictionless concept page.

## Verification

- `uv run mkdocs build` — succeeds; the two new internal `#anchor` links in `frictionless.md` resolve cleanly. All other build warnings are pre-existing (`PRD.md`, `llms.txt`).
- `uv run pytest` — 733 passed, 70 skipped, 2 failed. Both failing tests (`packages/gmnspy/tests/test_cli.py::test_quality_json_emits_issues_document` + `test_quality_never_exits_nonzero_on_warnings_only`) fail on `feat/docs-v2-foundation` without this change — pre-existing on the base branch, unrelated to docs.

## Scope notes

- Base branch is `feat/docs-v2-foundation`, not `refactor/v1.0`.
- The existing §6 prose is preserved verbatim; rationales are added as paragraphs after each default, not by rewriting.
- Did not edit any non-architecture pages (quickstarts, cookbook, reference) — those are different agents' scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)