### PR TITLE
docs(v2): cookbook recipes rewritten per new template (#96 v2)

### DIFF
--- a/docs/datagrove/cookbook/convert-formats.md
+++ b/docs/datagrove/cookbook/convert-formats.md
@@ -13,16 +13,25 @@ You have data in format X (a regulator handed you a folder of CSVs, an upstream 
 
 ## Quick example
 
+Convert the bundled Leavenworth CSV directory into a parquet directory. Destination extension determines the output format:
+
+```bash
+gmnspy convert packages/gmnspy/gmnspy/fixtures/leavenworth/csv ./leavenworth.parquet
+```
+
+Expected:
+
 ```text
-$ gmnspy convert packages/gmnspy/gmnspy/fixtures/leavenworth/csv ./leavenworth.parquet
 wrote 9 tables to ./leavenworth.parquet (parquet)
 ```
 
-That writes a parquet directory (one file per table) inferred from the destination extension. The same network reloads ~5× faster than the CSV directory it came from.
+The same network reloads ~5× faster than the CSV directory it came from.
 
 ## Step-by-step
 
 ### 1. Pick the destination format
+
+Each format has different trade-offs for cold-read latency, write speed, and predicate pushdown. Rule of thumb: **parquet for interchange, duckdb for repeated local use, zipcsv for emailing, csv only when a downstream tool demands it**.
 
 | Format | Cold read | Write | Predicate pushdown | Portability |
 |---|---|---|---|---|
@@ -31,22 +40,22 @@ That writes a parquet directory (one file per table) inferred from the destinati
 | `duckdb` (single file) | Fastest — pre-indexed, statistics cached. | Slowest — DDL + insert per table. | Yes — full SQL. | DuckDB-only readers. |
 | `zipcsv` (single `.zip`) | Slow — text decode after unzip. | Medium. | None. | Universal + single-file. |
 
-Rule of thumb: **parquet for interchange, duckdb for repeated local use, zipcsv for emailing, csv only when a downstream tool demands it**.
-
 ### 2. Run `gmnspy convert`
 
-```text
-$ gmnspy convert <source> <dest>
+The CLI infers format from the destination extension (`.parquet`, `.duckdb`, `.zip`) or from whether the target is an existing directory:
+
+```bash
+gmnspy convert <source> <dest>
 ```
 
-The format of `<dest>` is inferred from the extension (`.parquet`, `.duckdb`, `.zip`) or from whether it's an existing directory (CSV / Parquet). Override the inference with `--format`:
+Override the inference with `--format` when the extension is missing or ambiguous:
 
-```text
-$ gmnspy convert ./csv_dir ./out.duckdb --format duckdb
-$ gmnspy convert ./csv_dir ./out          --format parquet
+```bash
+gmnspy convert ./csv_dir ./out.duckdb --format duckdb
+gmnspy convert ./csv_dir ./out          --format parquet
 ```
 
-Or programmatically:
+The same dispatch is available from Python — `Network.write` and `Package.write` accept the same destination + optional `format=` kwarg as the CLI:
 
 ```python
 from gmnspy import Network
@@ -56,17 +65,17 @@ net = Network.from_source(leavenworth.csv_dir())
 net.write("./leavenworth.duckdb")
 ```
 
-`Network.write` and `Package.write` use the same dispatch as the CLI — extension inference plus an optional `format=` kwarg.
-
 ### 3. (Optional) Pick an engine
 
-```text
-$ gmnspy convert ./csv_dir ./out.parquet --engine pandas
+Switch to the pandas engine if you hit the null-typed column issue in [#163](https://github.com/e-lo/GMNSpy/issues/163) — DuckDB's strict typing rejects columns that are entirely null in the source, while pandas coerces them to object/None:
+
+```bash
+gmnspy convert ./csv_dir ./out.parquet --engine pandas
 ```
 
-The default is the ibis engine. Switch to `pandas` if you hit the null-typed column issue tracked in [#163](https://github.com/e-lo/GMNSpy/issues/163) — DuckDB's strict typing rejects columns that are entirely null in the source. The pandas engine coerces them to object/None so the write succeeds.
-
 ### 4. Verify the round-trip
+
+Load the destination back and validate against the spec. This catches any schema drift introduced by the conversion (e.g. a string column that came back as int because every value happened to parse):
 
 ```python
 from gmnspy import Network
@@ -77,27 +86,64 @@ assert report.passed, [i.code for i in report.issues if i.is_error()]
 print(f"{net.spec_version}: {net.links.count()} links — round-trip clean")
 ```
 
-Validation against the spec catches any schema drift introduced by the conversion (e.g. a string column that came back as int because every value happened to parse). See [validate-network](../../gmnspy/cookbook/validate-network.md) for what's in the report.
+See [validate-network](../../gmnspy/cookbook/validate-network.md) for what's in the report.
 
 ### 5. (Optional) Convert remote → local
 
-`convert` accepts the same URL surface as `from_source`, so cloud → local is a one-liner:
+`convert` accepts the same URL surface as `from_source`, so cloud → local is a one-liner. The download happens once; from then on you load the local copy:
 
-```text
-$ gmnspy convert s3://my-bucket/networks/leavenworth/ ./leavenworth.parquet
+```bash
+gmnspy convert s3://my-bucket/networks/leavenworth/ ./leavenworth.parquet
 ```
 
-That downloads once, writes parquet locally, and from then on you load the local copy. See [Read from S3](read-from-s3.md) for credential handling.
+See [Read from S3](read-from-s3.md) for credential handling.
 
 ## Common variations
 
-| You want... | Do this |
-|---|---|
-| Programmatic conversion | `Package.from_source(src).write(dest)` — same dispatch as the CLI. |
-| Re-pack only a few tables | `Package.from_source(src).select(["link", "node"]).write(dest)` — see [scope recipes](index.md#scope--geographic-subsetting) for FK-aware variants. |
-| Partitioned parquet | `--format parquet` to a directory and the writer will create one file per table. Per-table row-group partitioning is the parquet engine's default. |
-| Compress the CSV output | Convert to `zipcsv` instead — same wire format, 5-10× smaller. |
-| Validate during the write | `Package.from_source(src).validate().write(dest)` raises before writing if any ERROR finding fires. |
+???+ note "Default — CLI conversion with extension inference"
+    Most conversions are one-line CLI calls. The destination extension picks the format.
+
+    ```bash
+    gmnspy convert ./csv_dir ./out.parquet
+    ```
+
+??? note "Programmatic conversion in Python"
+    Same dispatch as the CLI; useful inside scripts and notebooks.
+
+    ```python
+    from datagrove.package import Package
+    Package.from_source(src).write(dest)
+    ```
+
+??? note "Re-pack only a subset of tables"
+    Keep just the tables you need; the writer drops the rest.
+
+    ```python
+    Package.from_source(src).select(["link", "node"]).write(dest)
+    ```
+
+    See the [scope recipes](index.md) for FK-aware variants that walk relationships.
+
+??? note "Partitioned parquet (one file per table)"
+    Pass a directory destination with `--format parquet`. The writer creates one file per table; per-table row-group partitioning is the parquet engine's default.
+
+    ```bash
+    gmnspy convert ./csv_dir ./parquet_dir --format parquet
+    ```
+
+??? note "Compress the CSV output (zipcsv)"
+    Same wire format as CSV but typically 5–10× smaller — useful for emailing or storing in artifact stores.
+
+    ```bash
+    gmnspy convert ./csv_dir ./out.zip --format zipcsv
+    ```
+
+??? note "Validate during the write"
+    Raises before writing if any ERROR finding fires.
+
+    ```python
+    Package.from_source(src).validate().write(dest)
+    ```
 
 ## Pitfalls
 

--- a/docs/datagrove/cookbook/read-from-s3.md
+++ b/docs/datagrove/cookbook/read-from-s3.md
@@ -13,25 +13,32 @@ Your data lives on cloud storage and you want the same lazy-load surface you get
 
 ## Quick example
 
+Open a package directly from S3 by URL. The default AWS credential chain (env vars, `~/.aws/credentials`, IAM role) is tried automatically — you only pass `credential=` when you need to override it.
+
 ```python
 from gmnspy import Network
 
 net = Network.from_source("s3://my-bucket/networks/leavenworth/")
 print(f"{net.spec_version}: {net.links.count()} links")
-# AWS creds discovered from the default chain — env, ~/.aws/credentials, IAM role.
 ```
 
-If your bucket is public-readable, no credential resolution runs at all. If it's private and a credential is discoverable, the load is still lazy — `net.links` is an ibis expression, not a materialised frame.
+Expected (will vary by network):
+
+```text
+0.97: 214 links
+```
+
+If your bucket is public-readable, no credential resolution runs at all. Either way the load is lazy — `net.links` is an ibis expression, not a materialised frame.
 
 ## Step-by-step
 
 ### 1. Install
 
-```text
-$ pip install 'gmnspy[server]'
-```
+Cloud filesystem drivers (`fsspec`, `s3fs`, `adlfs`, `gcsfs`) come with the `[server]`, `[clean]`, and `[mcp]` extras. If you only installed bare `gmnspy` and hit `ImportError: No module named 's3fs'`, that's the missing extra:
 
-The cloud filesystem drivers (`fsspec`, `s3fs`, `adlfs`, `gcsfs`) come along with the `[server]`, `[clean]`, and `[mcp]` extras. If you only installed the bare `gmnspy` and hit `ImportError: No module named 's3fs'`, that's the missing extra — re-install with one of those tags.
+```bash
+pip install 'gmnspy[server]'
+```
 
 ### 2. Provide credentials
 
@@ -44,7 +51,7 @@ Credentials cascade in a fixed order. The first one resolved wins:
 
 For AWS specifically, the default boto credential chain runs *inside* step 1 — IAM role, `~/.aws/credentials`, `AWS_*` env vars. You only need a `DATAGROVE_CRED_*` variable when the bucket needs a non-default credential (e.g. a different AWS account, a custom MinIO instance with HTTP Basic).
 
-To store a credential in the keyring (one-off, on dev machines):
+To store a credential in the keyring on a dev machine — once, interactively — call the keyring API directly:
 
 ```python
 import keyring
@@ -54,6 +61,8 @@ keyring.set_password("datagrove", "my-bucket", "AKIA…/secret-here")
 The same call from `python -c` works for CI bootstrapping if you'd rather not put the secret in an env file.
 
 ### 3. Load the package
+
+Discovery via the cascade is the common path. An explicit kwarg overrides discovery, which is handy in notebooks where you'd rather not depend on shell environment:
 
 ```python
 from gmnspy import Network
@@ -72,11 +81,12 @@ The result is the same `Network` you'd get from a local path. Every table (`net.
 
 ### 4. Verify the load is lazy
 
+Inspect the underlying expression and confirm it's an ibis `Table`. Then push a filter down — only matching rows transit:
+
 ```python
 expr = net.links.expr  # underlying ibis Table
 print(type(expr).__name__)  # 'Table'
 
-# No bytes pulled yet. Push a filter down — only matching rows transit:
 fast_links = net.links.filter(net.links.free_speed > 45.0).to_polars()
 ```
 
@@ -84,7 +94,7 @@ Filters and column projections push down to the parquet readers, so a 10 GB pack
 
 ### 5. Cache for repeat reads
 
-If the same script will hit the package many times — a notebook, a debugging loop, a CI matrix — convert it once and load locally:
+If the same script will hit the package many times — a notebook, a debugging loop, a CI matrix — convert it once and load locally afterwards:
 
 ```python
 from gmnspy import Network
@@ -100,13 +110,56 @@ Parquet is faster to re-read than CSV-over-S3 by an order of magnitude on cold c
 
 ## Common variations
 
-| Scheme | Install extra | Credential field | Notes |
-|---|---|---|---|
-| `s3://…` | `[server]` (s3fs) | AWS chain or `DATAGROVE_CRED_*_TOKEN` | Custom endpoints via `endpoint_url` kwarg. |
-| `https://…` | `[server]` (httpx) | `Bearer <token>` or HTTP Basic `user:pass` | Bearer is detected when token has no `:`. |
-| `az://container@account/…` | `[server]` (adlfs) | `DATAGROVE_CRED_<ACCOUNT>_TOKEN` | Account key, SAS token, or default Azure credential. |
-| `gs://bucket/…` | `[server]` (gcsfs) | GCP application-default creds or service-account JSON path | Set `GOOGLE_APPLICATION_CREDENTIALS` for the file path. |
-| `duckdb://https://…/file.duckdb` | bare `gmnspy` | HTTP creds as above | DuckDB native httpfs reader; one round-trip per table. |
+???+ note "S3 (default) — AWS chain or `DATAGROVE_CRED_*_TOKEN`"
+    Requires `pip install 'gmnspy[server]'` (brings in `s3fs`). The boto chain handles standard AWS auth automatically. Custom endpoints (MinIO, R2, Wasabi) need an `endpoint_url` kwarg.
+
+    ```python
+    net = Network.from_source(
+        "s3://my-bucket/networks/leavenworth/",
+        endpoint_url="https://s3.us-west-2.minio.local",
+    )
+    ```
+
+??? note "HTTPS with bearer token or HTTP Basic"
+    Bearer is detected when the token has no `:`; pass `user:pass` for HTTP Basic.
+
+    ```python
+    net = Network.from_source(
+        "https://data.example.org/networks/leavenworth/",
+        credential="ey...JWT...",
+    )
+    ```
+
+??? note "Azure Blob Storage (`az://`)"
+    Requires `adlfs` from the `[server]` extra. Credential can be an account key, SAS token, or default Azure credential chain.
+
+    ```python
+    net = Network.from_source("az://container@account/networks/leavenworth/")
+    ```
+
+??? note "Google Cloud Storage (`gs://`)"
+    Requires `gcsfs` from the `[server]` extra. Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of your service-account JSON file.
+
+    ```python
+    net = Network.from_source("gs://my-bucket/networks/leavenworth/")
+    ```
+
+??? note "DuckDB over HTTP"
+    Single-file DuckDB databases read directly over HTTPS via the native `httpfs` reader — one round-trip per table.
+
+    ```python
+    net = Network.from_source("duckdb://https://data.example.org/leavenworth.duckdb")
+    ```
+
+??? note "Force anonymous reads on a public bucket"
+    The AWS chain still attempts to sign requests if any credential is present in the environment. Force unsigned access:
+
+    ```python
+    net = Network.from_source(
+        "s3://public-open-data/networks/leavenworth/",
+        credential={"anon": True},
+    )
+    ```
 
 ## Pitfalls
 

--- a/docs/datagrove/cookbook/scope-bbox.md
+++ b/docs/datagrove/cookbook/scope-bbox.md
@@ -13,6 +13,8 @@ You have a spatial filter — a bounding box from a map UI, a polygon from a pla
 
 ## Quick example
 
+Load the bundled Leavenworth fixture, build a bbox view over the links table, and count the rows that fall inside:
+
 ```python
 from gmnspy import Network
 from gmnspy.fixtures import leavenworth
@@ -23,9 +25,13 @@ view = from_bbox(net.links, minx=-120.67, miny=47.58, maxx=-120.65, maxy=47.60)
 print(f"{view.count()} links in bbox")
 ```
 
+The view is lazy — no rows materialise until you call `.to_pandas()` or iterate.
+
 ## Step-by-step
 
 ### 1. Bounding box (any table)
+
+`from_bbox` is generic — it works on any `Table` whose schema declares a WKT geometry column. No shapely required for bbox; the predicate is pure coordinate math:
 
 ```python
 from datagrove.dataset.view import from_bbox
@@ -34,9 +40,9 @@ view = from_bbox(net.links, minx=-120.67, miny=47.58, maxx=-120.65, maxy=47.60)
 df = view.to_pandas()
 ```
 
-`from_bbox` is generic — it works on any `Table` whose schema declares a WKT geometry column. No shapely required for bbox; the predicate is pure coordinate math.
-
 ### 2. Polygon (shapely or WKT)
+
+For non-rectangular regions, pass a shapely `Polygon`. Shapely is in the `[clean]` extra:
 
 ```python
 from datagrove.dataset.view import from_polygon
@@ -52,7 +58,7 @@ poly = Polygon([
 view = from_polygon(net.links, poly)
 ```
 
-If shapely isn't installed, pass a WKT string:
+If shapely isn't installed, pass a WKT string instead — the function parses it directly:
 
 ```python
 view = from_polygon(net.links, "POLYGON((-120.67 47.58, -120.65 47.58, ...))")
@@ -60,7 +66,7 @@ view = from_polygon(net.links, "POLYGON((-120.67 47.58, -120.65 47.58, ...))")
 
 ### 3. Buffered geometry
 
-Buffer a geometry (in metres, regardless of CRS — the helper reprojects) and filter to anything inside:
+Buffer a geometry (in metres, regardless of CRS — the helper reprojects) and filter to anything inside. Useful for "everything within 100 m of this corridor":
 
 ```python
 from datagrove.dataset.view import from_geometry_buffer
@@ -72,7 +78,7 @@ view = from_geometry_buffer(net.links, corridor, distance_m=100)
 
 ### 4. Predicate pushdown
 
-When the underlying source is partitioned Parquet, the spatial predicate compiles to a single DuckDB `WHERE` clause. Partitions whose statistics fall entirely outside the bbox are pruned before reading. Typical speed-up on a regional network is 10-50× vs full scan.
+When the underlying source is partitioned Parquet, the spatial predicate compiles to a single DuckDB `WHERE` clause. Partitions whose statistics fall entirely outside the bbox are pruned before reading. Typical speed-up on a regional network is 10–50× vs full scan:
 
 ```python
 net = Network.from_source("s3://my-bucket/regional/links.parquet")
@@ -84,7 +90,7 @@ Inspect the compiled predicate via `view.explain()` — useful when debugging "w
 
 ### 5. Compose with other filters
 
-Spatial views compose with the rest of the `View` API:
+Spatial views compose with the rest of the `View` API. The bbox + facility-type predicate fuse into a single SQL pass — no intermediate materialisation:
 
 ```python
 inside = from_bbox(net.links, -120.67, 47.58, -120.65, 47.60)
@@ -92,16 +98,42 @@ arterials = inside.filter(net.links.facility_type == "arterial")
 arterials.to_pandas()
 ```
 
-That filter compiles to a single SQL pass — the bbox + facility-type predicate fuse, no intermediate materialisation.
-
 ## Common variations
 
-| You want... | Use |
-|---|---|
-| Filter one table | `from_bbox(net.links, ...)` returns a lazy `View` |
-| Filter the whole network | `gmnspy.scope.from_polygon(net, poly)` — FK pushdown across all tables |
-| WGS84 bbox on a projected source | reproject the bbox first; `from_bbox` doesn't reproject |
-| A buffered point | `from_geometry_buffer(net.links, Point(lon, lat), distance_m=500)` |
+???+ note "Default — bbox filter on a single table"
+    Returns a lazy `View` over the matched rows.
+
+    ```python
+    view = from_bbox(net.links, minx, miny, maxx, maxy)
+    ```
+
+??? note "Filter the whole network with FK pushdown"
+    For GMNS networks, use the gmnspy scope ops instead — they walk the FK graph and produce a fully consistent sub-network.
+
+    ```python
+    from gmnspy.scope import from_polygon
+    scope = from_polygon(net, poly)
+    sub = scope.apply()
+    ```
+
+??? note "WGS84 bbox against a projected source"
+    `from_bbox` compares numbers; it does not reproject. Reproject the bbox to the source CRS first.
+
+    ```python
+    from pyproj import Transformer
+    t = Transformer.from_crs("EPSG:4326", net.spec.crs, always_xy=True)
+    minx, miny = t.transform(-120.67, 47.58)
+    maxx, maxy = t.transform(-120.65, 47.60)
+    view = from_bbox(net.links, minx, miny, maxx, maxy)
+    ```
+
+??? note "Buffered point (everything within 500 m of a location)"
+    `from_geometry_buffer` accepts any shapely geometry — `Point`, `LineString`, `Polygon`.
+
+    ```python
+    from shapely.geometry import Point
+    view = from_geometry_buffer(net.links, Point(-120.66, 47.59), distance_m=500)
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/customise-quality.md
+++ b/docs/gmnspy/cookbook/customise-quality.md
@@ -17,6 +17,8 @@ GMNS defaults are designed for typical mid-sized urban networks. Override them w
 
 ## Quick example
 
+Tighten the residential-speed threshold from the default 35 mph down to 30 mph. `RuleConfig.thresholds` merges into the rule's defaults — you only specify the keys you want to change:
+
 ```python
 from gmnspy import Network
 from gmnspy.fixtures import leavenworth
@@ -30,9 +32,14 @@ report = run_quality(
 print(f"{len(report.issues)} issues at the lower 30 mph threshold")
 ```
 
+![Quality report card for the Leavenworth fixture](../../assets/screenshots/leavenworth-quality-report.png){ .screenshot }
+*Quality report card. The custom 30 mph threshold surfaces a handful of extra residential-speed warnings that the default 35 mph threshold would have hidden.*
+
 ## Step-by-step
 
 ### 1. List the rules currently registered
+
+Inspect the registered rule pack to see codes, defaults, and severities. The GMNS pack ships seven rules out of the box:
 
 ```python
 from datagrove.quality import list_rules
@@ -40,8 +47,6 @@ from datagrove.quality import list_rules
 for rule in list_rules():
     print(f"{rule.code:42} {rule.severity.value:8} {rule.description[:50]}")
 ```
-
-The GMNS rule pack registers seven rules out of the box:
 
 | Code | Threshold key | Default | Severity |
 |---|---|---|---|
@@ -55,7 +60,7 @@ The GMNS rule pack registers seven rules out of the box:
 
 ### 2. Override a threshold
 
-`RuleConfig.thresholds` is merged into the rule's defaults — you only specify the keys you want to change:
+`RuleConfig.thresholds` is merged into the rule's defaults — you only specify the keys you want to change. Override multiple rules in one call:
 
 ```python
 report = run_quality(
@@ -69,6 +74,8 @@ report = run_quality(
 
 ### 3. Disable a rule entirely
 
+A disabled rule produces no issues and isn't listed in the report:
+
 ```python
 report = run_quality(
     net,
@@ -76,11 +83,9 @@ report = run_quality(
 )
 ```
 
-A disabled rule produces no issues and isn't listed in the report.
-
 ### 4. Promote (or demote) severity
 
-A common case: your CI pipeline should fail on lane-count mismatches even though the rule ships as WARNING.
+A common case: your CI pipeline should fail on lane-count mismatches even though the rule ships as WARNING. Use `severity_override` to promote, then check `report.issues` and exit non-zero accordingly:
 
 ```python
 from datagrove.reports import Severity
@@ -94,7 +99,7 @@ exit(1 if any(i.severity is Severity.ERROR for i in report.issues) else 0)
 
 ### 5. Write your own rule and register it
 
-A rule is a class with five attributes + a `run` method:
+A rule is a class with five attributes plus a `run` generator. Yield one `Issue` per finding; let `config.severity_override` win if it's set so callers can promote / demote the rule:
 
 ```python
 from datagrove.quality import Rule, register_rule
@@ -122,12 +127,49 @@ class NoTollLinksRule(Rule):
 register_rule(NoTollLinksRule())
 ```
 
-Or declare it via the `datagrove.quality.rules` entry point in `pyproject.toml` so it auto-registers on import:
+For auto-registration on import, declare the rule via the `datagrove.quality.rules` entry point in your package's `pyproject.toml`:
 
 ```toml
 [project.entry-points."datagrove.quality.rules"]
 no_toll_links = "myproject.rules:NoTollLinksRule"
 ```
+
+## Common variations
+
+???+ note "Default — override one threshold for one run"
+    Most common pattern: tighten or loosen a single threshold without touching anything else.
+
+    ```python
+    report = run_quality(
+        net,
+        config={"quality.high_speed_residential": RuleConfig(thresholds={"speed_limit_mph": 30.0})},
+    )
+    ```
+
+??? note "Silence a noisy rule entirely"
+    Disable it via `RuleConfig(enabled=False)`; the rule contributes no issues and doesn't appear in the report.
+
+    ```python
+    report = run_quality(net, config={"quality.orphan_node": RuleConfig(enabled=False)})
+    ```
+
+??? note "Promote a WARNING to ERROR for CI"
+    Use `severity_override`; then exit non-zero if any ERROR issue appears.
+
+    ```python
+    report = run_quality(
+        net,
+        config={"quality.lane_count_mismatch": RuleConfig(severity_override=Severity.ERROR)},
+    )
+    ```
+
+??? note "Ship a custom rule with your package"
+    Register via the `datagrove.quality.rules` entry point so it auto-loads on import.
+
+    ```toml
+    [project.entry-points."datagrove.quality.rules"]
+    no_toll_links = "myproject.rules:NoTollLinksRule"
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/edit-with-rollback.md
+++ b/docs/gmnspy/cookbook/edit-with-rollback.md
@@ -13,6 +13,8 @@ You're applying a destructive operation to a network — simplify geometry, merg
 
 ## Quick example
 
+Open a session, run a geometry simplification, and exit cleanly so the edit commits. Then write the result out:
+
 ```python
 from gmnspy import Network
 from gmnspy.fixtures import leavenworth
@@ -30,17 +32,22 @@ net.write("./leavenworth-simplified.parquet")
 
 If the `with` block raises, the session rolls back all ops and `net` is byte-identical to the pre-edit state.
 
+![Diff card showing the simplify_geometry result on Leavenworth](../../assets/screenshots/leavenworth-simplify-edit-result.png){ .screenshot }
+*EditResult diff card: per-table row counts (added / removed / changed) plus a before/after geometry preview.*
+
 ## Step-by-step
 
 ### 1. Install
 
-```text
-$ pip install 'gmnspy[clean]'
+The `[clean]` extra brings in `shapely` and `igraph`, which most of the editing ops depend on for geometry / connectivity work:
+
+```bash
+pip install 'gmnspy[clean]'
 ```
 
-The `[clean]` extra brings in `shapely` and `igraph`, which most of the editing ops depend on for geometry / connectivity work.
-
 ### 2. Open a Session
+
+A `Session` wraps the network in an editable view. Inside the `with` block you pass *both* `net` and `s` into each editing op — the op uses `net` to read state and `s` to record the change so the session can undo it later:
 
 ```python
 from datagrove.editing import Session
@@ -49,9 +56,9 @@ with Session(net) as s:
     ...
 ```
 
-A `Session` wraps the network in an editable view. Inside the `with` block you pass *both* `net` and `s` into each editing op — the op uses `net` to read state and `s` to record the change so the session can undo it later.
-
 ### 3. Apply one or more ops
+
+Multiple ops in the same `with` block share a single transactional boundary — rollback undoes all of them:
 
 ```python
 from gmnspy.clean import simplify_geometry, merge_close_nodes, remove_orphans
@@ -62,7 +69,7 @@ with Session(net) as s:
     r3 = remove_orphans(net, s)
 ```
 
-Each call returns an `EditResult`:
+Each call returns an `EditResult` with three fields:
 
 | Field | Type | Description |
 |---|---|---|
@@ -72,7 +79,7 @@ Each call returns an `EditResult`:
 
 ### 4. Commit or rollback
 
-Clean exit from the `with` block commits all ops. Anything else rolls back in LIFO order:
+Clean exit from the `with` block commits all ops. An exception or an explicit `s.rollback()` undoes them in LIFO order:
 
 ```python
 # Commit:
@@ -97,13 +104,15 @@ with Session(net) as s:
 
 ### 5. Persist the edit log (optional)
 
+Pass `log_path=` to write a chronological record of each op (name, params, diff, rollback blob) to a sidecar parquet. The log is the only way to undo edits across process boundaries:
+
 ```python
 with Session(net, log_path="history.parquet") as s:
     simplify_geometry(net, s, mode="redundant_only")
     merge_close_nodes(net, s, threshold="2m")
 ```
 
-The session writes a chronological record of each op (name, params, diff, rollback blob) to `history.parquet`. Later, in a fresh process:
+Later, in a fresh process, replay the log in LIFO to undo:
 
 ```python
 from datagrove.editing import rollback
@@ -112,15 +121,17 @@ net = Network.from_source("./edited.parquet")
 rollback(net, log_path="history.parquet")  # replay in LIFO
 ```
 
-This is the same mechanism the CLI's `--dry-run` uses, and the only way to undo edits across process boundaries.
+This is the same mechanism the CLI's `--dry-run` uses.
 
 ### 6. Write the result
+
+Persist the edited network. If you see an `OutOfSyncWarning` when running outside the CLI, that's [#164](https://github.com/e-lo/GMNSpy/issues/164) — an FK index didn't refresh after the edit:
 
 ```python
 net.write("./leavenworth-edited.parquet")
 ```
 
-If you see an `OutOfSyncWarning` here when running outside the CLI, that's [#164](https://github.com/e-lo/GMNSpy/issues/164) — an FK index didn't refresh after the edit. Workaround until the fix lands:
+Workaround until the fix lands — call `recompute_fks` explicitly before the write:
 
 ```python
 net.recompute_fks()
@@ -129,13 +140,52 @@ net.write("./leavenworth-edited.parquet")
 
 ## Common variations
 
-| You want... | Do this |
-|---|---|
-| Preview without committing | `gmnspy clean simplify-geometry <src> --dry-run` — runs the op, prints the diff, never writes. |
-| Chain ops in one transactional block | Put multiple ops in the same `with Session(net) as s:` block. Rollback undoes all of them. |
-| Run one op via the CLI | `gmnspy clean simplify-geometry <src> --mode redundant_only --out ./out.parquet`. |
-| Capture diffs for a PR description | `result.diff` has a `_repr_html_` — display in a notebook or `print(result.diff)` for plain text. |
-| Replay only the last N ops | Trim `history.parquet` before calling `rollback`, or pass `n=N` if your version supports it (see [API reference](../reference/api.md)). |
+???+ note "Default — transactional block with a single op"
+    Most common pattern: open session, run one op, exit cleanly to commit.
+
+    ```python
+    with Session(net) as s:
+        simplify_geometry(net, s, mode="redundant_only")
+    ```
+
+??? note "Chain multiple ops in one atomic block"
+    All-or-nothing: rollback undoes the whole batch.
+
+    ```python
+    with Session(net) as s:
+        simplify_geometry(net, s, mode="redundant_only")
+        merge_close_nodes(net, s, threshold="2m")
+        remove_orphans(net, s)
+    ```
+
+??? note "Preview without committing"
+    `--dry-run` on the CLI runs the op, prints the diff, and reverts before exit.
+
+    ```bash
+    gmnspy clean simplify-geometry <src> --dry-run
+    ```
+
+??? note "Run one op from the shell"
+    Useful in pipelines; the CLI handles `recompute_fks` for you.
+
+    ```bash
+    gmnspy clean simplify-geometry <src> --mode redundant_only --out ./out.parquet
+    ```
+
+??? note "Capture the diff for a PR description"
+    `Diff` ships a `_repr_html_` for notebooks and a clean `__str__` for plain text.
+
+    ```python
+    print(result.diff)
+    ```
+
+??? note "Replay an edit log to undo across processes"
+    The log is a parquet sidecar; pass the path and `rollback` replays in LIFO.
+
+    ```python
+    from datagrove.editing import rollback
+    rollback(net, log_path="history.parquet")
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/run-bench.md
+++ b/docs/gmnspy/cookbook/run-bench.md
@@ -13,8 +13,15 @@ You want a fast read on how `gmnspy` performs on your hardware against your netw
 
 ## Quick example
 
-```text
-$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
+Run the bench against the bundled Leavenworth fixture. Add `--json` to any `gmnspy` (or `datagrove`) CLI command and the output becomes a single machine-readable JSON document on stdout — pipe into `jq`, save to a file, feed to a script or AI agent. Default output is human-readable rich panels:
+
+```bash
+gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
+```
+
+Expected:
+
+```json
 {
   "source": "packages/gmnspy/gmnspy/fixtures/leavenworth/csv",
   "engine": "ibis",
@@ -32,39 +39,39 @@ $ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
 
 ### 1. Run against the bundled reference
 
-```text
-$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv
-```
+The Leavenworth fixture is small (214 links / 75 nodes) — total runtime is under a second. It's a baseline, not a benchmark; useful for confirming nothing's wrong with the install:
 
-The Leavenworth fixture is small (214 links / 75 nodes) — total runtime is under a second. It's a baseline, not a benchmark; useful for confirming nothing's wrong with the install.
+```bash
+gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+```
 
 ### 2. Run against your own network
 
-```text
-$ gmnspy bench /path/to/my/network --json > bench.json
-```
+Same command, different path. The bench accepts the same source surface as `Network.from_source` — local dirs, `s3://`, `duckdb://`, etc.:
 
-Same command, different path. The bench accepts the same source surface as `Network.from_source` — local dirs, `s3://`, `duckdb://`, etc.
+```bash
+gmnspy bench /path/to/my/network --json > bench.json
+```
 
 ### 3. Compare engines
 
-```text
-$ gmnspy bench /path/to/net --engine ibis --json > ibis.json
-$ gmnspy bench /path/to/net --engine pandas --json > pandas.json
-$ gmnspy bench /path/to/net --engine polars --json > polars.json
-```
+`ibis` (the default) typically wins for partitioned Parquet on a fast disk; `polars` wins for CSV bulk loads; `pandas` is the slowest of the three on anything > 100k rows but is the most portable:
 
-Typical patterns: `ibis` (the default) wins for partitioned Parquet on a fast disk; `polars` wins for CSV bulk loads; `pandas` is the slowest of the three on anything > 100k rows but is the most portable.
+```bash
+gmnspy bench /path/to/net --engine ibis --json > ibis.json
+gmnspy bench /path/to/net --engine pandas --json > pandas.json
+gmnspy bench /path/to/net --engine polars --json > polars.json
+```
 
 ### 4. Capture a baseline for CI
 
-For regression tracking, save a baseline JSON in-repo and compare on every PR:
+For regression tracking, save a baseline JSON in-repo and compare on every PR. A 30% tolerance is reasonable for the Leavenworth fixture given timing noise; tighten on larger networks:
 
-```text
-$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-baseline.json
-$ # in CI:
-$ gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-current.json
-$ python -c "
+```bash
+gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-baseline.json
+# in CI:
+gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json > bench-current.json
+python -c "
 import json
 b = json.load(open('bench-baseline.json'))['total_seconds']
 c = json.load(open('bench-current.json'))['total_seconds']
@@ -72,11 +79,9 @@ assert c < b * 1.3, f'regression: {c:.2f}s vs baseline {b:.2f}s (+{(c/b-1)*100:.
 "
 ```
 
-A 30% tolerance is reasonable for the Leavenworth fixture given timing noise; tighten on larger networks.
-
 ### 5. Read the JSON
 
-The shape is stable inside a major version:
+The shape is stable inside a major version. Each phase is one logical operation: `load` opens the package and instantiates the engine; `validate` runs structural + schema + FK + sync passes; `quality` runs the GMNS rule pack; `connectivity` builds the igraph index and counts components:
 
 ```json
 {
@@ -94,16 +99,44 @@ The shape is stable inside a major version:
 }
 ```
 
-Each phase is one logical operation: `load` opens the package and instantiates the engine; `validate` runs structural + schema + FK + sync passes; `quality` runs the GMNS rule pack; `connectivity` builds the igraph index and counts components.
-
 ## Common variations
 
-| You want... | Pipe through |
-|---|---|
-| Just the total | `jq -r .total_seconds bench.json` |
-| Phase breakdown as CSV | `jq -r '.phases[] \| [.name,.seconds] \| @csv' bench.json` |
-| CI regression check | save baseline `bench.json`; compare with `jq -e '.total_seconds < 5.0'` |
-| Engine sweep | shell loop over `--engine ibis pandas polars` with `--json` |
+???+ note "Default — Leavenworth fixture, JSON out"
+    Quickest smoke-test that the install works and the engine is wired up.
+
+    ```bash
+    gmnspy bench packages/gmnspy/gmnspy/fixtures/leavenworth/csv --json
+    ```
+
+??? note "Just the total seconds (for shell pipelines)"
+    Pipe through `jq` to extract a single number.
+
+    ```bash
+    gmnspy bench ./my-net --json | jq -r .total_seconds
+    ```
+
+??? note "Phase breakdown as CSV"
+    For charting or copying into a spreadsheet.
+
+    ```bash
+    gmnspy bench ./my-net --json | jq -r '.phases[] | [.name,.seconds] | @csv'
+    ```
+
+??? note "CI regression check (one-liner)"
+    Fails the CI step if the total exceeds your budget.
+
+    ```bash
+    gmnspy bench ./my-net --json | jq -e '.total_seconds < 5.0'
+    ```
+
+??? note "Engine sweep"
+    Loop over engines in shell and compare.
+
+    ```bash
+    for e in ibis pandas polars; do
+      gmnspy bench ./my-net --engine "$e" --json > "bench-$e.json"
+    done
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/scope-from-nodes.md
+++ b/docs/gmnspy/cookbook/scope-from-nodes.md
@@ -13,6 +13,8 @@ You have a list of node ids (e.g. study-area boundary nodes, signalised intersec
 
 ## Quick example
 
+Build a scope from three seed nodes. With `path_between=True` (the default), BFS shortest paths between every pair of seeds determine what's included; `.apply()` materialises the result as a normal `Network`:
+
 ```python
 from gmnspy import Network
 from gmnspy.fixtures import leavenworth
@@ -23,15 +25,18 @@ sub = from_nodes(net, [1, 25, 50], path_between=True).apply()
 print(f"scoped: {sub.links.count()} links, {sub.nodes.count()} nodes")
 ```
 
+![Scoped Leavenworth subnetwork rendered on a folium map](../../assets/screenshots/leavenworth-scoped-map.png){ .screenshot }
+*The scope from seed nodes 1, 25, and 50. Shortest paths between the seeds determine which interior links are kept; every dependent `lane`, `link_tod`, and signal row is FK-filtered automatically.*
+
 ## Step-by-step
 
 ### 1. Install the `[clean]` extra
 
-```text
-$ pip install 'gmnspy[clean]'
-```
+`from_nodes` walks the network graph via igraph; that's in the `[clean]` extra. Without it you get an `ImportError` pointing at the missing dependency:
 
-`from_nodes` walks the network graph via igraph; that's in the `[clean]` extra. Without it you get an `ImportError` pointing at the missing dependency.
+```bash
+pip install 'gmnspy[clean]'
+```
 
 ### 2. Decide `path_between=True` vs `False`
 
@@ -39,6 +44,8 @@ $ pip install 'gmnspy[clean]'
 * `path_between=False` — keeps just the seed nodes and their incident links. Useful when the seeds already describe a closed region and you don't want extra interior links.
 
 ### 3. Build the scope (lazy)
+
+A `Scope` is a description of *which rows* belong to the subset, not the subset itself. `scope.provenance` records how it was built (operation, seeds, parameters) for audit / debugging:
 
 ```python
 scope = from_nodes(net, [1, 25, 50], path_between=True)
@@ -48,9 +55,9 @@ print(f"links in scope:    {len(scope.link_ids)}")
 print(f"provenance reason: {scope.provenance.reason}")
 ```
 
-A `Scope` is a description of *which rows* belong to the subset, not the subset itself. `scope.provenance` records how it was built (operation, seeds, parameters) for audit / debugging.
-
 ### 4. Apply to materialise a sub-network
+
+`.apply()` returns a normal `Network` you can validate, run quality checks on, or write out. Every table is pre-filtered by FK chain — lane rows whose `link_id` isn't in scope are dropped, signal phases for missing signals are dropped, etc.:
 
 ```python
 sub = scope.apply()
@@ -63,11 +70,9 @@ sub = scope.apply()
 #   ...
 ```
 
-`sub` is a normal `Network` — validate it, run quality checks, write it out.
-
 ### 5. Chain with set ops + buffers
 
-Scopes compose:
+Scopes compose with union / intersect / subtract and with network / spatial buffering. Build a corridor scope, union with a downtown scope, then add a half-mile network buffer in one expression:
 
 ```python
 from gmnspy.scope import from_nodes, from_point
@@ -82,8 +87,15 @@ sub = combined.apply()
 
 ### 6. CLI equivalent
 
-```text
-$ gmnspy scope from-nodes packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 25 50 --json
+The same operation runs from the shell. Add `--json` to any `gmnspy` (or `datagrove`) CLI command and the output becomes a single machine-readable JSON document on stdout — pipe into `jq`, save to a file, feed to a script or AI agent. Default output is human-readable rich panels:
+
+```bash
+gmnspy scope from-nodes packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 25 50 --json
+```
+
+Expected:
+
+```json
 {
   "operation": "from_nodes",
   "seed_node_ids": [1, 25, 50],
@@ -95,13 +107,52 @@ $ gmnspy scope from-nodes packages/gmnspy/gmnspy/fixtures/leavenworth/csv 1 25 5
 
 ## Common variations
 
-| You have... | Use |
-|---|---|
-| A single seed + max distance | `from_node(net, 1, network_buffer="200m")` |
-| One link + buffer | `from_link(net, 42, spatial_buffer="100m")` (or `network_buffer=`) |
-| A lon/lat point | `from_point(net, lon, lat, spatial_buffer="500m")` (snaps to nearest link) |
-| A whole connected component | `connected_component(net, seed_node_id=1)` |
-| A zone polygon | `from_zone(net, zone_id=12)` |
+???+ note "Default — multi-node BFS with path_between"
+    Most common pattern: a handful of seed ids, paths between them filled in automatically.
+
+    ```python
+    sub = from_nodes(net, [1, 25, 50], path_between=True).apply()
+    ```
+
+??? note "Single seed with a network-distance buffer"
+    Expands outward from one node along network edges up to a budget.
+
+    ```python
+    from gmnspy.scope import from_node
+    sub = from_node(net, 1, network_buffer="200m").apply()
+    ```
+
+??? note "Single link with a spatial buffer"
+    Useful for corridor studies. Accepts either spatial (meters) or network (graph-distance) buffer.
+
+    ```python
+    from gmnspy.scope import from_link
+    sub = from_link(net, 42, spatial_buffer="100m").apply()
+    ```
+
+??? note "Lat/lon point with auto-snapping"
+    Snaps to the nearest link and buffers from there.
+
+    ```python
+    from gmnspy.scope import from_point
+    sub = from_point(net, lon=-120.66, lat=47.59, spatial_buffer="500m").apply()
+    ```
+
+??? note "Whole connected component"
+    Drops everything not reachable from the seed via the graph.
+
+    ```python
+    from gmnspy.scope import connected_component
+    sub = connected_component(net, seed_node_id=1).apply()
+    ```
+
+??? note "A pre-defined zone polygon"
+    Pulls geometry from the `zone` table and scopes by polygon.
+
+    ```python
+    from gmnspy.scope import from_zone
+    sub = from_zone(net, zone_id=12).apply()
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/serve-http.md
+++ b/docs/gmnspy/cookbook/serve-http.md
@@ -13,6 +13,8 @@ You want HTTP access to your GMNS networks — for dashboards, non-Python consum
 
 ## Quick example
 
+Write a minimal config that binds localhost on port 8000, requires a bearer token, and exposes one package. Start it with `gmnspy server run`:
+
 ```yaml
 # server.yaml
 bind: 127.0.0.1
@@ -25,32 +27,49 @@ packages:
     source: packages/gmnspy/gmnspy/fixtures/leavenworth/csv
 ```
 
+```bash
+gmnspy server run --config server.yaml
+```
+
+Expected:
+
 ```text
-$ gmnspy server run --config server.yaml
 INFO:     Uvicorn running on http://127.0.0.1:8000
 ```
+
+![Interactive OpenAPI docs for the gmnspy HTTP server](../../assets/screenshots/serve-http-openapi.png){ .screenshot }
+*Interactive OpenAPI at `/docs` — every endpoint with try-it-out forms and the JSON response schema.*
 
 ## Step-by-step
 
 ### 1. Install the `[server]` extra
 
-```text
-$ pip install 'gmnspy[server]'
-```
+Brings in FastAPI + uvicorn + the auth dependencies:
 
-Brings in FastAPI + uvicorn + the auth dependencies.
+```bash
+pip install 'gmnspy[server]'
+```
 
 ### 2. Generate a dev token
 
+The dev-token helper prints both the raw token (which clients use) and the Argon2 hash (which the server stores). The raw token is never persisted server-side:
+
+```bash
+python -c "from datagrove.api import generate_dev_token; print(generate_dev_token())"
+```
+
+Expected:
+
 ```text
-$ python -c "from datagrove.api import generate_dev_token; print(generate_dev_token())"
 token:     7yK3-...-Q9p
 token_hash: $argon2id$v=19$m=65536,t=3,p=4$...
 ```
 
-Save the raw `token` somewhere safe (clients need it); paste `token_hash` into your config. The raw token is never stored on the server.
+Save the raw `token` somewhere safe; paste `token_hash` into your config.
 
 ### 3. Write a config YAML
+
+A config declares network bind, auth mode, and one entry per exposed package. Sources accept any path or URL that `Network.from_source` accepts:
 
 ```yaml
 # server.yaml
@@ -74,22 +93,42 @@ logging:
 
 ### 4. Run it + verify
 
-```text
-$ gmnspy server run --config server.yaml
-$ curl http://127.0.0.1:8000/health
+Start the server, then hit `/health` (the unauthenticated liveness probe) to confirm it's up:
+
+```bash
+gmnspy server run --config server.yaml
+```
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Expected:
+
+```json
 {"status": "ok", "version": "1.0.0"}
 ```
 
 ### 5. Make authenticated requests
 
-```text
-$ TOKEN="7yK3-...-Q9p"
-$ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/networks
-[{"id": "leavenworth", "spec_version": "0.97", "link_count": 214, ...}]
+Pass the raw token from step 2 as a bearer header. The server returns JSON by default and HTML when the request sets `Accept: text/html`:
 
-$ curl -H "Authorization: Bearer $TOKEN" \
-       http://127.0.0.1:8000/networks/leavenworth/quality
-{"issues": [...], "spec_version": "0.97"}
+```bash
+TOKEN="7yK3-...-Q9p"
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/networks
+```
+
+Expected:
+
+```json
+[{"id": "leavenworth", "spec_version": "0.97", "link_count": 214, ...}]
+```
+
+Run quality checks with a POST:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+     http://127.0.0.1:8000/networks/leavenworth/quality
 ```
 
 ### 6. Endpoint list
@@ -109,13 +148,58 @@ Interactive OpenAPI at `http://127.0.0.1:8000/docs`.
 
 ## Common variations
 
-| You want... | Change |
-|---|---|
-| Off-host access | `bind: 0.0.0.0` *and keep auth on* |
-| Behind nginx / Caddy | Bind to `127.0.0.1`; let the proxy terminate TLS + forward |
-| Multiple tokens (per client) | List under `auth.token_hashes:` instead of `auth.token_hash:` |
-| Disable auth (dev only) | `auth: { mode: none }` — refuses to start unless bound to localhost |
-| Docker | Dockerfile is on the Phase 5 roadmap; for now `pip install` in your own image and copy the config |
+???+ note "Default — localhost bind with bearer auth"
+    Safe default for dev and single-host production behind a reverse proxy.
+
+    ```yaml
+    bind: 127.0.0.1
+    auth: { mode: bearer, token_hash: "$argon2id$..." }
+    ```
+
+??? note "Off-host access (LAN, etc.)"
+    Bind `0.0.0.0` — but keep auth on.
+
+    ```yaml
+    bind: 0.0.0.0
+    auth: { mode: bearer, token_hash: "$argon2id$..." }
+    ```
+
+??? note "Behind nginx / Caddy"
+    Bind to `127.0.0.1`; let the proxy terminate TLS and forward. No server-side TLS config needed.
+
+    ```yaml
+    bind: 127.0.0.1
+    port: 8000
+    ```
+
+??? note "Multiple tokens (one per client)"
+    Use the plural `token_hashes:` form; clients still pass a single bearer header.
+
+    ```yaml
+    auth:
+      mode: bearer
+      token_hashes:
+        - "$argon2id$...client-a..."
+        - "$argon2id$...client-b..."
+    ```
+
+??? note "Disable auth (dev only)"
+    Server refuses to start unless bound to localhost.
+
+    ```yaml
+    bind: 127.0.0.1
+    auth: { mode: none }
+    ```
+
+??? note "Docker"
+    Dockerfile is on the Phase 5 roadmap; for now `pip install` in your own image and copy the config alongside.
+
+    ```dockerfile
+    FROM python:3.12-slim
+    RUN pip install 'gmnspy[server]'
+    COPY server.yaml /etc/gmnspy/server.yaml
+    CMD ["gmnspy", "server", "run", "--config", "/etc/gmnspy/server.yaml"]
+    ```
 
 ## Pitfalls
 

--- a/docs/gmnspy/cookbook/serve-mcp.md
+++ b/docs/gmnspy/cookbook/serve-mcp.md
@@ -13,7 +13,7 @@ You want an AI agent (Claude Desktop, Claude Code, any MCP-aware host) to call `
 
 ## Quick example
 
-Add this to your MCP host config, restart, and ask the agent "describe the package at /tmp/leavenworth/csv":
+Add this entry to your MCP host config, restart the host, and ask the agent "describe the package at /tmp/leavenworth/csv". The agent picks `describe_package`, calls it with `{"source": "/tmp/leavenworth/csv"}`, and surfaces the spec version, table counts, and FK summary back in chat:
 
 ```json
 {
@@ -26,33 +26,39 @@ Add this to your MCP host config, restart, and ask the agent "describe the packa
 }
 ```
 
-The agent will pick `describe_package`, call it with `{"source": "/tmp/leavenworth/csv"}`, and surface the spec version, table counts, and FK summary back in chat.
+![Claude Desktop calling the gmnspy describe_package tool](../../assets/screenshots/serve-mcp-claude.png){ .screenshot }
+*Claude Desktop invoking the gmnspy MCP server — tool name, arguments, and the JSON response inline in the chat.*
 
 ## Step-by-step
 
 ### 1. Install
 
-```text
-$ pip install 'gmnspy[mcp]'
-```
+The `[mcp]` extra brings in `mcp` (the official Python SDK). If you've already installed `[clean]` or `[server]`, only the MCP SDK is added:
 
-The `[mcp]` extra brings in `mcp` (the official Python SDK). If you've already installed `[clean]` or `[server]`, only the MCP SDK is added.
+```bash
+pip install 'gmnspy[mcp]'
+```
 
 ### 2. Test the server runs
 
+You don't normally launch the server yourself — the MCP host does it. But `--help` confirms the entry point resolves and the SDK is importable:
+
+```bash
+gmnspy mcp serve --help
+```
+
+Expected:
+
 ```text
-$ gmnspy mcp serve --help
 Usage: gmnspy mcp serve [OPTIONS]
 
   Start the gmnspy MCP server (stdio transport).
   ...
 ```
 
-You don't normally launch the server yourself — the MCP host does it. But `--help` confirms the entry point resolves and the SDK is importable.
-
 ### 3. Configure the MCP host
 
-**Claude Desktop (macOS):** edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+**Claude Desktop (macOS):** edit `~/Library/Application Support/Claude/claude_desktop_config.json`. On Linux it's `~/.config/Claude/claude_desktop_config.json`; on Windows, `%APPDATA%\Claude\claude_desktop_config.json`. Restart Claude Desktop after editing; the tools show up under a hammer-icon in the chat input:
 
 ```json
 {
@@ -65,9 +71,7 @@ You don't normally launch the server yourself — the MCP host does it. But `--h
 }
 ```
 
-On Linux it's `~/.config/Claude/claude_desktop_config.json`; on Windows, `%APPDATA%\Claude\claude_desktop_config.json`. Restart Claude Desktop after editing. The tools show up under a hammer-icon in the chat input.
-
-**Claude Code:** add `.mcp.json` to the root of your project:
+**Claude Code:** add `.mcp.json` to the root of your project. Claude Code picks it up on session start. To use the version installed in a project venv, replace `command` with the absolute path to that venv's `gmnspy`:
 
 ```json
 {
@@ -79,12 +83,10 @@ On Linux it's `~/.config/Claude/claude_desktop_config.json`; on Windows, `%APPDA
   }
 }
 ```
-
-Claude Code picks it up on session start. To use the version installed in a project venv, replace `command` with the absolute path to that venv's `gmnspy`.
 
 ### 4. The tools shipped today
 
-The server exposes 7 stateless tools. Each takes a JSON object and returns a JSON document. Sources are paths or URLs that `Network.from_source` accepts.
+The server exposes 7 stateless tools. Each takes a JSON object and returns a JSON document. Sources are paths or URLs that `Network.from_source` accepts:
 
 | Name | Summary | Inputs | Output |
 |---|---|---|---|
@@ -98,7 +100,7 @@ The server exposes 7 stateless tools. Each takes a JSON object and returns a JSO
 
 ### 5. Sample agent prompts
 
-Each of these exercises a different tool — paste them into a chat with the server configured to see the agent pick the right call.
+Each of these exercises a different tool — paste them into a chat with the server configured to see the agent pick the right call:
 
 * **"What's in the package at `packages/gmnspy/gmnspy/fixtures/leavenworth/csv`?"** — agent calls `describe_package`, returns spec version + per-table rowcounts.
 * **"Validate that package and tell me about any ERROR-severity issues."** — agent calls `validate_package`, filters the response, and surfaces just the failures.
@@ -106,12 +108,67 @@ Each of these exercises a different tool — paste them into a chat with the ser
 
 ## Common variations
 
-| You want... | Do this |
-|---|---|
-| Rename the server in the host UI | `"args": ["mcp", "serve", "--name", "gmns-leavenworth"]` — the name appears under the tool list in Claude. |
-| Run inside a project venv | Replace `"command": "gmnspy"` with the absolute path to that venv's `gmnspy` binary, e.g. `"command": "/path/to/.venv/bin/gmnspy"`. |
-| Pin the server to a specific working directory | Add `"cwd": "/abs/path/to/data"` to the JSON entry; all relative-path tool calls resolve there. |
-| Pass env vars (cloud creds) | Add `"env": {"AWS_PROFILE": "ds-readonly"}` to the JSON entry. |
+???+ note "Default — stdio transport, system gmnspy"
+    The simplest config: relies on `gmnspy` being on the MCP host's `PATH`.
+
+    ```json
+    {
+      "mcpServers": {
+        "gmnspy": { "command": "gmnspy", "args": ["mcp", "serve"] }
+      }
+    }
+    ```
+
+??? note "Rename the server in the host UI"
+    `--name` becomes the label under the tool list in Claude.
+
+    ```json
+    "args": ["mcp", "serve", "--name", "gmns-leavenworth"]
+    ```
+
+??? note "Run inside a project venv"
+    Use the absolute path to that venv's `gmnspy` binary; avoids version skew with the system install.
+
+    ```json
+    {
+      "mcpServers": {
+        "gmnspy": {
+          "command": "/path/to/.venv/bin/gmnspy",
+          "args": ["mcp", "serve"]
+        }
+      }
+    }
+    ```
+
+??? note "Pin the server to a working directory"
+    Adds `cwd` so all relative-path tool calls resolve from a known root.
+
+    ```json
+    {
+      "mcpServers": {
+        "gmnspy": {
+          "command": "gmnspy",
+          "args": ["mcp", "serve"],
+          "cwd": "/abs/path/to/data"
+        }
+      }
+    }
+    ```
+
+??? note "Pass env vars (cloud creds)"
+    Use `env` to inject credentials into the subprocess.
+
+    ```json
+    {
+      "mcpServers": {
+        "gmnspy": {
+          "command": "gmnspy",
+          "args": ["mcp", "serve"],
+          "env": { "AWS_PROFILE": "ds-readonly" }
+        }
+      }
+    }
+    ```
 
 ## Pitfalls
 
@@ -123,5 +180,5 @@ Each of these exercises a different tool — paste them into a chat with the ser
 ## See also
 
 * [Architecture](../../shared/architecture.md) — MCP server position in the v1.0 surface layering.
-* [Use the `--json` CLI contract from a tool-call loop](index.md#for-ai-agents-specifically) — when you want an agent to drive `gmnspy` via shell instead of MCP.
+* [Drive the CLI from an AI agent loop](../../shared/ai/json-cli.md) — when you want an agent to drive `gmnspy` via shell instead of MCP.
 * [API reference](../reference/api.md) — the Python entry points the MCP tools wrap.

--- a/docs/gmnspy/cookbook/validate-network.md
+++ b/docs/gmnspy/cookbook/validate-network.md
@@ -13,12 +13,19 @@ You have a GMNS network — yours, a vendor's, the output of an edit — and you
 
 ## Quick example
 
-```text
-$ gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+Validate the bundled Leavenworth fixture from the shell. Add `--json` to any `gmnspy` (or `datagrove`) CLI command and the output becomes a single machine-readable JSON document on stdout — pipe into `jq`, save to a file, feed to a script or AI agent. Default output is human-readable rich panels.
+
+```bash
+gmnspy validate --json packages/gmnspy/gmnspy/fixtures/leavenworth/csv
+```
+
+Expected (Leavenworth is clean, so the issue list is empty):
+
+```json
 {"spec_version": "0.97", "passed": true, "issues": [], ...}
 ```
 
-Or from Python:
+The same call from Python returns a `ValidationReport` dataclass:
 
 ```python
 from gmnspy import Network
@@ -29,23 +36,28 @@ report = net.validate()
 print(f"passed={report.passed}  issues={len(report.issues)}")
 ```
 
-The Leavenworth fixture is clean, so the issue list is empty and `passed` is `True`. The CLI exits non-zero if any ERROR-severity finding fires.
+The CLI exits non-zero if any ERROR-severity finding fires, so it drops straight into a CI gate.
+
+![Validation report card for the Leavenworth fixture](../../assets/screenshots/leavenworth-validation-report.png){ .screenshot }
+*Validation report card. Zero ERRORs (Leavenworth is clean); a handful of DATA_QUALITY warnings from the residential-speed rule.*
 
 ## Step-by-step
 
 ### 1. Run validation
+
+`net.validate()` runs all four passes — structural, schema, FK, sync-state — and returns a `ValidationReport`. Restrict to a subset with `passes=`:
 
 ```python
 report = net.validate()                              # all four passes
 report = net.validate(passes=["schema", "fk"])       # only two of them
 ```
 
-Equivalent CLI:
+The same operation is available from the shell, with three output formats:
 
-```text
-$ gmnspy validate <source>                  # human-readable summary
-$ gmnspy validate <source> --json           # machine-readable
-$ gmnspy validate <source> --format html    # standalone HTML report
+```bash
+gmnspy validate <source>                  # human-readable summary
+gmnspy validate <source> --json           # machine-readable
+gmnspy validate <source> --format html    # standalone HTML report
 ```
 
 ### 2. Read the report shape
@@ -58,7 +70,7 @@ $ gmnspy validate <source> --format html    # standalone HTML report
 | `report.spec_version` | `str` | The GMNS spec version the validator ran against. |
 | `report.issues` | `list[Issue]` | One entry per finding. |
 
-Each `Issue` carries:
+Each `Issue` is a small dataclass carrying severity, category, a stable code, a human-readable message, and the offending row coordinates when known:
 
 ```python
 @dataclass
@@ -75,6 +87,8 @@ class Issue:
 
 ### 3. Filter by severity
 
+Most CI gates want `if errors: sys.exit(1)`. The CLI does this for you; from Python it's a one-liner:
+
 ```python
 from datagrove.validation import Severity
 
@@ -82,9 +96,9 @@ errors = [i for i in report.issues if i.severity is Severity.ERROR]
 warnings = [i for i in report.issues if i.severity is Severity.WARNING]
 ```
 
-Most CI gates want `if errors: sys.exit(1)`. The CLI does this for you.
-
 ### 4. Filter by category
+
+Categories group findings by which validation pass produced them:
 
 ```python
 from datagrove.validation import Category
@@ -93,15 +107,15 @@ schema_problems = [i for i in report.issues if i.category is Category.SCHEMA]
 fk_problems = [i for i in report.issues if i.category is Category.FOREIGN_KEY]
 ```
 
-Categories let you group findings by which validation pass produced them:
-
 * `SCHEMA` — field-level type / enum / required-column violations.
 * `STRUCTURAL` — package-level shape problems (missing required table, missing required file).
 * `FOREIGN_KEY` — cross-table integrity (`link.from_node_id` points at a node that doesn't exist).
 * `SYNC_STATE` — FKs that resolved on disk but were invalidated by an in-memory edit (see [edit-with-rollback](edit-with-rollback.md)).
-* `DATA_QUALITY` — rule-pack findings (high-speed-residential, lane-count-mismatch, etc.). Always WARNING / INFO; see [customise the quality pack](index.md#validation--data-quality).
+* `DATA_QUALITY` — rule-pack findings (high-speed-residential, lane-count-mismatch, etc.). Always WARNING / INFO; see [customise the quality pack](customise-quality.md).
 
 ### 5. Common codes you'll see
+
+Stable identifier strings let you script around specific findings without parsing free-text messages. The full list lives in `datagrove.validation.codes`:
 
 | Code | Category | Severity | What it means |
 |---|---|---|---|
@@ -115,22 +129,63 @@ Categories let you group findings by which validation pass produced them:
 | `sync.fk_stale` | SYNC_STATE | ERROR | An edit invalidated an FK and no `recompute` ran. |
 | `quality.high_speed_residential` | DATA_QUALITY | WARNING | Residential link with speed limit above the configured threshold. |
 
-The full list lives in `datagrove.validation.codes` and is enumerated in the [reference](../reference/api.md).
-
 ## Common variations
 
-| You want... | Do this |
-|---|---|
-| HTML report for a stakeholder | `report.to_html("report.html")` or `gmnspy validate <src> --format html > report.html`. |
-| Just the failing tables | `{i.table for i in report.issues if i.is_error()}`. |
-| Embed validation in a CI step | `gmnspy validate <src>` — non-zero exit code on ERROR, no extra wiring needed. |
-| Pretty-print in a notebook | `report` renders an HTML summary via `_repr_html_` — call `display(report)` or just leave it as the last cell expression. |
-| Server response | The HTTP server returns JSON by default and HTML when the request sets `Accept: text/html`. |
+???+ note "Default — full validation, rich console output"
+    The most common path: run all four passes and read the panel.
+
+    ```bash
+    gmnspy validate <source>
+    ```
+
+??? note "JSON for scripts and AI agents"
+    `--json` emits one parseable document on stdout — exits non-zero on ERROR.
+
+    ```bash
+    gmnspy validate <source> --json | jq '.issues[] | select(.severity=="error")'
+    ```
+
+??? note "Standalone HTML report for a stakeholder"
+    Self-contained file you can email or upload to a docs site.
+
+    ```bash
+    gmnspy validate <source> --format html > report.html
+    ```
+
+    Or programmatically:
+
+    ```python
+    report.to_html("report.html")
+    ```
+
+??? note "Just the failing tables"
+    Useful for triaging which datasets need attention first.
+
+    ```python
+    failing = {i.table for i in report.issues if i.is_error()}
+    ```
+
+??? note "Embed in a CI step"
+    Non-zero exit code on ERROR — no extra wiring needed.
+
+    ```bash
+    gmnspy validate ./data || exit 1
+    ```
+
+??? note "Pretty-print in a notebook"
+    `ValidationReport` ships a `_repr_html_`; just leave it as the last cell expression.
+
+    ```python
+    report  # renders an HTML summary in Jupyter
+    ```
+
+??? note "Server response"
+    The HTTP server returns JSON by default and HTML when the request sets `Accept: text/html`. See [serve-http](serve-http.md).
 
 ## Pitfalls
 
 * **WARNING-level findings don't fail CI.** That's intentional — data-quality findings are advisory. If you want them to be blocking, post-process: `if any(i.code.startswith("quality.") for i in report.issues): sys.exit(1)`.
-* **Data-quality thresholds are configurable.** A WARNING firing on your network may just mean the default threshold doesn't match your context (e.g. metric vs imperial speed). See the [customise the quality pack](index.md#validation--data-quality) recipe.
+* **Data-quality thresholds are configurable.** A WARNING firing on your network may just mean the default threshold doesn't match your context (e.g. metric vs imperial speed). See the [customise the quality pack](customise-quality.md) recipe.
 * **`sync.fk_stale` only fires after an edit.** A freshly-loaded package can't be out of sync with itself. If you see this in CI, an upstream step in the same process mutated the network.
 * **The validator runs against the spec version embedded in the package.** Override with `Network.from_source(path, spec_version="0.96")` if the package is mislabeled.
 

--- a/docs/shared/ai/json-cli.md
+++ b/docs/shared/ai/json-cli.md
@@ -13,6 +13,8 @@ You're building an agent loop (Claude Code, a LangChain tool, a one-off shell ha
 
 ## Quick example
 
+Wrap `gmnspy validate --json` as a Python tool the LLM can invoke. The function parses stdout, summarises the report, and caps the issue list to keep agent context cost predictable:
+
 ```python
 import json, subprocess
 
@@ -37,20 +39,22 @@ print(validate("packages/gmnspy/gmnspy/fixtures/leavenworth/csv"))
 
 ### 1. Every command supports `--json`
 
-```text
-$ gmnspy info     --json <source>
-$ gmnspy validate --json <source>
-$ gmnspy quality  --json <source>
-$ gmnspy scope from-nodes --json <source> 1 25 50
-$ gmnspy clean    --json <source>
-$ gmnspy bench    --json <source>
+Add `--json` to any `gmnspy` (or `datagrove`) CLI command and the output becomes a single machine-readable JSON document on stdout — pipe into `jq`, save to a file, feed to a script or AI agent. Default output is human-readable rich panels:
+
+```bash
+gmnspy info     --json <source>
+gmnspy validate --json <source>
+gmnspy quality  --json <source>
+gmnspy scope from-nodes --json <source> 1 25 50
+gmnspy clean    --json <source>
+gmnspy bench    --json <source>
 ```
 
 The `--json` contract: exactly one parseable JSON document on stdout, no log prefix, no progress bars, no trailing whitespace. `json.loads(proc.stdout)` always works on a successful run.
 
 ### 2. Stderr stays separate
 
-Rich output (panels, tables, progress, approval prompts) goes to stderr. With `--json` on stdout the parser stays clean even when an approval prompt fires on stderr — the agent loop can either suppress stderr or surface it as side-channel feedback.
+Rich output (panels, tables, progress, approval prompts) goes to stderr. With `--json` on stdout the parser stays clean even when an approval prompt fires on stderr — the agent loop can either suppress stderr or surface it as side-channel feedback:
 
 ```python
 result = subprocess.run(
@@ -63,7 +67,7 @@ diagnostics = result.stderr             # human-readable, optional to display
 
 ### 3. Pre-approve gated operations
 
-Mutating commands (`clean`, edit sessions) prompt for confirmation by default. In an agent loop, set the env var once instead of repeating `--yes` per call:
+Mutating commands (`clean`, edit sessions) prompt for confirmation by default. In an agent loop, set the env var once instead of repeating `--yes` per call. The env var is preferable for agents because it scopes to the process tree and survives `subprocess` calls from inside the loop:
 
 ```python
 import os, subprocess
@@ -71,7 +75,7 @@ env = {**os.environ, "DATAGROVE_AUTO_APPROVE": "1"}
 subprocess.run(["gmnspy", "clean", "--json", source], env=env, check=False)
 ```
 
-`--yes` on the command line works too. The env var is preferable for agents because it scopes to the process tree and survives `subprocess` calls from inside the loop.
+`--yes` on the command line works too.
 
 ### 4. Schema stability
 
@@ -87,6 +91,8 @@ Full details: [API reference](../../gmnspy/reference/api.md).
 
 ### 5. Exit codes
 
+Check `returncode` *and* parse the JSON in agent loops — `returncode != 0` plus an `issues` array tells the model what went wrong:
+
 | Command | Exit 0 | Exit 1 | Exit 2 |
 |---|---|---|---|
 | `validate` | no ERROR-severity issues | ≥1 ERROR issue | CLI usage error |
@@ -94,16 +100,31 @@ Full details: [API reference](../../gmnspy/reference/api.md).
 | `clean` / edit | success or pure dry-run | failed precondition | CLI usage error |
 | others | success | unhandled error | CLI usage error |
 
-In agent loops, check `returncode` *and* parse the JSON — `returncode != 0` plus an `issues` array tells the model what went wrong.
-
 ## Common variations
 
-| You want... | Pipe through |
-|---|---|
-| Quick filter on the shell | `gmnspy validate --json src \| jq '.issues[] \| select(.severity=="error")'` |
-| One-liner in Python | `json.loads(subprocess.check_output(["gmnspy", "info", "--json", src]))` |
-| Stateful flow (sessions, history) | use MCP — see [Wire the MCP server](../../gmnspy/cookbook/serve-mcp.md) |
-| Streaming output | not supported; commands emit one document on completion |
+???+ note "Default — `subprocess.run` + `json.loads`"
+    The simplest pattern: one shell out, one JSON parse, hand the dict back to the model.
+
+    ```python
+    import json, subprocess
+    out = subprocess.check_output(["gmnspy", "info", "--json", src])
+    report = json.loads(out)
+    ```
+
+??? note "Quick shell filter via `jq`"
+    Useful inside ad-hoc agent shells where you want only ERROR issues.
+
+    ```bash
+    gmnspy validate --json src | jq '.issues[] | select(.severity=="error")'
+    ```
+
+??? note "Stateful flows (sessions, history)"
+    The CLI is stateless. For multi-step agent flows that need to inspect intermediate state, use MCP instead.
+
+    See [Wire the MCP server](../../gmnspy/cookbook/serve-mcp.md).
+
+??? note "Streaming output"
+    Not supported — commands emit one document on completion. For long-running operations, poll a sidecar log or use the HTTP server.
 
 ## Pitfalls
 
@@ -114,4 +135,4 @@ In agent loops, check `returncode` *and* parse the JSON — `returncode != 0` pl
 ## See also
 
 * [MCP tools reference](../../gmnspy/ai/mcp-tools.md) — richer, stateful surface for agents that can speak MCP.
-* [AI surface](../ai/index.md) — how `--json` fits with `llms.txt`, `api-index.json`, and the Claude Code Skills.
+* [AI surface](index.md) — how `--json` fits with `llms.txt`, `api-index.json`, and the Claude Code Skills.


### PR DESCRIPTION
## Summary

Rewrites all 11 cookbook recipes (3 datagrove, 7 gmnspy, 1 shared/ai) to follow the new docs v2 patterns established in `docs/_page-style-guide.md` and the `docs/gmnspy/index.md` exemplar.

Each page now:

- Leads every code block with 1-3 sentences of prose explaining what the code does and why
- Tags every code fence with its language (`python`, `bash`, `yaml`, `json`, `toml`)
- Replaces 'Common variations' tables with collapsible accordion admonitions (`???+` for the default-expanded path, `???` for the rest)
- Expands the `--json` contract explanation once per recipe that mentions it (then short references after)
- Adds screenshot placeholders on visual-output pages (validation, quality, scope, edit, serve-http, serve-mcp) — actual PNGs land via task #18
- Preserves all working code samples

## Pages

**datagrove cookbook:**
- `docs/datagrove/cookbook/read-from-s3.md`
- `docs/datagrove/cookbook/convert-formats.md`
- `docs/datagrove/cookbook/scope-bbox.md`

**gmnspy cookbook:**
- `docs/gmnspy/cookbook/validate-network.md`
- `docs/gmnspy/cookbook/customise-quality.md`
- `docs/gmnspy/cookbook/scope-from-nodes.md`
- `docs/gmnspy/cookbook/edit-with-rollback.md`
- `docs/gmnspy/cookbook/serve-http.md`
- `docs/gmnspy/cookbook/serve-mcp.md`
- `docs/gmnspy/cookbook/run-bench.md`

**shared/ai:**
- `docs/shared/ai/json-cli.md`

## Test plan

- [x] `mkdocs build` — no new ERROR-level failures; only expected screenshot-link warnings for placeholders staged for task #18
- [x] `pytest` — 2 pre-existing failures (missing `igraph`) unrelated to docs changes
- [x] Cross-links checked against build warnings; no new broken links introduced

## Deferred

- Quickstart, visual tour, and what-is-gmns pages (different agent in this wave)
- Architecture / Frictionless concept pages (different agent)
- Actual screenshot PNGs (#18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)