### PR TITLE
feat(ci): Phase 5 hardening — coverage gate + bench + spec-sync + release-drafter + Docker

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,112 @@
+# release-drafter config for the GMNSpy + datagrove monorepo.
+#
+# Auto-drafts GitHub release notes from merged PR titles + labels using the
+# conventional-commits style we already write ("feat:", "fix:", "docs:", ...).
+# The human releaser just edits and publishes.
+#
+# v1.0 decision: ONE combined draft for the whole monorepo. release-drafter
+# can filter PRs with `include-paths:`, but it produces a single draft per
+# config file — splitting datagrove vs gmnspy into two distinct drafts would
+# need two config files + two workflows + `tag-prefix` filtering per side.
+# Defer that until the package release cadences actually diverge. When we do
+# split, the per-package configs would add e.g.:
+#   include-paths:
+#     - packages/datagrove/**
+# and the matching workflow would key off `datagrove-v*` tags.
+
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+
+# Semver bump from PR labels (set by autolabeler below or by humans).
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feat
+      - type:feature
+      - ":rocket: feature"
+  patch:
+    labels:
+      - fix
+      - type:bug
+      - ":bug: bug"
+  default: patch
+
+categories:
+  - title: "🚨 Breaking changes"
+    labels:
+      - breaking
+  - title: "✨ Features"
+    labels:
+      - feat
+      - type:feature
+      - ":rocket: feature"
+  - title: "🐛 Bug fixes"
+    labels:
+      - fix
+      - type:bug
+      - ":bug: bug"
+  - title: "📚 Documentation"
+    labels:
+      - docs
+      - type:docs
+      - ":blue_book:docs"
+  - title: "🔧 CI / Build"
+    labels:
+      - ci
+      - chore
+      - type:ci
+      - ":broom: chore"
+  - title: "🧪 Tests"
+    labels:
+      - test
+      - type:test
+  - title: "🏗️ Refactor"
+    labels:
+      - refactor
+      - type:refactor
+      - ":building_construction: refactor"
+
+# Auto-label PRs by conventional-commit title prefix so humans don't have to.
+# Matches both `feat:` and `feat(scope):` forms (case-insensitive).
+autolabeler:
+  - label: breaking
+    title:
+      - "/^[a-z]+(\\([^)]+\\))?!:/i"
+      - "/breaking[ -]change/i"
+  - label: feat
+    title:
+      - "/^feat(\\([^)]+\\))?:/i"
+  - label: fix
+    title:
+      - "/^fix(\\([^)]+\\))?:/i"
+  - label: docs
+    title:
+      - "/^docs(\\([^)]+\\))?:/i"
+  - label: ci
+    title:
+      - "/^ci(\\([^)]+\\))?:/i"
+  - label: chore
+    title:
+      - "/^chore(\\([^)]+\\))?:/i"
+  - label: test
+    title:
+      - "/^test(\\([^)]+\\))?:/i"
+  - label: refactor
+    title:
+      - "/^refactor(\\([^)]+\\))?:/i"
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+exclude-labels:
+  - skip-changelog
+
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,106 @@
+name: Bench
+
+# Performance regression guard.
+#
+# Runs pytest-benchmark on PRs that touch performance-critical paths,
+# stores the JSON output as a workflow artifact, and compares against
+# the most recent main-branch baseline (fetched from prior runs of
+# this workflow). Fails if any benchmark regresses >2x vs baseline.
+#
+# Task 5.2 future-proofs this workflow: as of 2026-05-27 the repo has
+# no benchmark tests yet (no `@pytest.mark.benchmark` fixtures and no
+# `tests/bench/`). The bench-run step is a no-op until they appear,
+# which is reported clearly in the job log.
+#
+# TODO(v1.1): post comparison as a PR comment via actions/github-script.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/datagrove/datagrove/engines/**'
+      - 'packages/datagrove/datagrove/io/**'
+      - 'packages/datagrove/datagrove/validation/**'
+      - 'packages/datagrove/datagrove/dataset/**'
+      - 'packages/gmnspy/gmnspy/network.py'
+      - 'packages/gmnspy/gmnspy/quality/**'
+      - 'packages/gmnspy/gmnspy/scope/**'
+      - 'packages/gmnspy/gmnspy/indexes/**'
+      - '.github/workflows/bench.yml'
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          python-version: '3.13'
+      - name: Install workspace
+        # --all-extras matches tests.yml so doctest-modules collection
+        # works the same and optional-dep bench paths are importable.
+        # pytest-benchmark is already in [dependency-groups].dev.
+        run: uv sync --all-packages --all-extras
+
+      - name: Discover bench tests
+        id: discover
+        # Look for explicit perf marker first, then tests/bench/ dirs,
+        # then test_bench_*.py files. Sets `found=true` and a `paths`
+        # output for the run step to consume.
+        run: |
+          set -e
+          if uv run pytest --collect-only -q -m perf 2>/dev/null | grep -q '::'; then
+            echo "mode=marker" >> "$GITHUB_OUTPUT"
+            echo "found=true"  >> "$GITHUB_OUTPUT"
+          elif find packages -type d -path '*/tests/bench' | grep -q .; then
+            echo "mode=dir"    >> "$GITHUB_OUTPUT"
+            echo "found=true"  >> "$GITHUB_OUTPUT"
+          elif find packages -name 'test_bench_*.py' | grep -q .; then
+            echo "mode=glob"   >> "$GITHUB_OUTPUT"
+            echo "found=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "no bench tests found — task 5.2 future-proofs the workflow"
+          fi
+
+      - name: Download baseline (most recent main-branch run)
+        if: steps.discover.outputs.found == 'true'
+        uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
+        with:
+          workflow: bench.yml
+          branch: main
+          name_is_regexp: true
+          name: '^bench-.*\.json$'
+          path: .benchmarks/baseline
+          if_no_artifact_found: warn
+
+      - name: Run benchmarks
+        if: steps.discover.outputs.found == 'true'
+        # --benchmark-compare-fail=mean:200% trips if mean is >2x baseline.
+        # When no baseline file is present pytest-benchmark just saves the
+        # new run as the first baseline (no compare, no fail).
+        run: |
+          mkdir -p .benchmarks
+          BASELINE=""
+          if compgen -G ".benchmarks/baseline/*.json" > /dev/null; then
+            cp .benchmarks/baseline/*.json .benchmarks/
+            BASELINE="--benchmark-compare --benchmark-compare-fail=mean:200%"
+          fi
+          case "${{ steps.discover.outputs.mode }}" in
+            marker) TARGET="-m perf" ;;
+            dir)    TARGET="packages/*/tests/bench" ;;
+            glob)   TARGET="-k bench_" ;;
+          esac
+          uv run pytest $TARGET \
+            --benchmark-only \
+            --benchmark-json=.benchmarks/bench-${{ github.sha }}.json \
+            $BASELINE
+
+      - name: Upload bench results
+        if: steps.discover.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ github.sha }}.json
+          path: .benchmarks/bench-${{ github.sha }}.json
+          retention-days: 90

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,6 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        # Bootstrap caveat: release-drafter reads its config from the
+        # default branch only. Until this workflow + config land on
+        # the default branch (currently `develop`), runs will fail
+        # with "Configuration file ... is not found". Treat as
+        # non-blocking until the bootstrap merge propagates. After
+        # that, REMOVE this continue-on-error and let real config
+        # errors fail loudly.
+        continue-on-error: true
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,34 @@
+# Drafts GitHub release notes from merged PR titles + labels.
+#
+# Per-package-tag aware: triggered by every push to refactor/v1.0 / main.
+# When the next `datagrove-vX.Y.Z` or `gmnspy-vX.Y.Z` tag is cut, the resulting
+# draft release notes pull from PRs merged since the previous matching tag.
+#
+# For v1.0 this is one combined draft across the monorepo (see
+# .github/release-drafter.yml for the rationale and the future split shape).
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - refactor/v1.0
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write       # create / update the draft release
+      pull-requests: write  # autolabeler writes labels back to PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -1,0 +1,131 @@
+name: Spec sync
+
+# Daily check for new upstream GMNS spec releases
+# (https://github.com/zephyr-data-specs/GMNS). When a tag exists upstream
+# that we have not yet vendored under packages/gmnspy/gmnspy/spec/, this
+# workflow opens a PR vendoring it side-by-side. The reviewer is then
+# responsible for updating SUPPORTED_SPECS / DEFAULT_SPEC in
+# packages/gmnspy/gmnspy/spec/__init__.py. We do NOT auto-merge.
+
+on:
+  schedule:
+    - cron: "0 12 * * *"  # 12:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      UPSTREAM: zephyr-data-specs/GMNS
+      BASE_BRANCH: refactor/v1.0
+      SPEC_DIR: packages/gmnspy/gmnspy/spec
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: refactor/v1.0
+
+      - name: Find first un-vendored upstream release
+        id: pick
+        run: |
+          set -euo pipefail
+          # Upstream tags look like "v0.97". Strip the leading "v" so they
+          # line up with our on-disk version directories (e.g. "0.97").
+          upstream=$(gh api "repos/${UPSTREAM}/releases" --paginate \
+            --jq '.[].tag_name' | sed 's/^v//' | sort -V)
+          vendored=$(ls "${SPEC_DIR}" | grep -E '^[0-9]+\.[0-9]+$' || true)
+          # One new version per run — keeps each PR scoped and reviewable.
+          new=$(comm -23 <(echo "$upstream" | sort -u) <(echo "$vendored" | sort -u) \
+            | sort -V | head -n1)
+          if [ -z "$new" ]; then
+            echo "No new upstream releases. Exiting cleanly."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New version detected: v${new}"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "version=${new}" >> "$GITHUB_OUTPUT"
+            echo "tag=v${new}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Vendor spec files
+        if: steps.pick.outputs.found == 'true'
+        env:
+          VERSION: ${{ steps.pick.outputs.version }}
+          TAG: ${{ steps.pick.outputs.tag }}
+        run: |
+          set -euo pipefail
+          dest="${SPEC_DIR}/${VERSION}"
+          mkdir -p "$dest"
+          # Fetch the listing of upstream Specification/ at this tag, then
+          # download every file (not subdirs) into the vendored dir. We
+          # don't filter by extension — upstream sometimes ships
+          # shared_categories.json, README.md, etc. alongside the schemas.
+          gh api "repos/${UPSTREAM}/contents/Specification?ref=${TAG}" \
+            --jq '.[] | select(.type=="file") | [.name, .download_url] | @tsv' \
+            > /tmp/files.tsv
+          while IFS=$'\t' read -r name url; do
+            echo "  fetching ${name}"
+            curl -fsSL "$url" -o "${dest}/${name}"
+          done < /tmp/files.tsv
+          # VERSION file is our convention, not upstream's — write the
+          # bare version string with a trailing newline (see 0.95/VERSION).
+          echo "${VERSION}" > "${dest}/VERSION"
+          ls "$dest"
+
+      - name: Commit, push, and open PR
+        if: steps.pick.outputs.found == 'true'
+        env:
+          VERSION: ${{ steps.pick.outputs.version }}
+          TAG: ${{ steps.pick.outputs.tag }}
+        run: |
+          set -euo pipefail
+          branch="spec-sync/${TAG}"
+          # Bail out gracefully if a sync PR for this version is already
+          # open or merged — avoids re-pushing on top of a maintainer's
+          # in-flight review.
+          if gh api "repos/${GITHUB_REPOSITORY}/branches/${branch}" >/dev/null 2>&1; then
+            echo "Branch ${branch} already exists upstream. Nothing to do."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add "${SPEC_DIR}/${VERSION}"
+          git commit -m "$(cat <<EOF
+          chore(spec): vendor GMNS spec ${TAG}
+
+          Vendored from ${UPSTREAM}@${TAG} by the spec-sync workflow.
+
+          Co-Authored-By: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          EOF
+          )"
+          git push -u origin "$branch"
+
+          body=$(cat <<EOF
+          Automated vendor of [GMNS ${TAG}](https://github.com/${UPSTREAM}/releases/tag/${TAG}).
+
+          ## What this PR does
+          - Adds \`${SPEC_DIR}/${VERSION}/\` with the upstream \`Specification/\` files plus a \`VERSION\` marker.
+
+          ## Reviewer checklist
+          - [ ] Add \`"${VERSION}"\` to \`SUPPORTED_SPECS\` in \`packages/gmnspy/gmnspy/spec/__init__.py\`.
+          - [ ] If 0.95 (\`gmns.spec.json\`) vs 0.96+ (\`datapackage.json\`) convention differs, update \`_DESCRIPTOR_FILENAME\` in the same file.
+          - [ ] Consider bumping \`DEFAULT_SPEC\` to \`"${VERSION}"\` if this release is stable.
+          - [ ] Spot-check the schema diff against the previous vendored version.
+          - [ ] Run the test suite locally — multi-version fixtures may need updating.
+
+          Upstream release: https://github.com/${UPSTREAM}/releases/tag/${TAG}
+          EOF
+          )
+          gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${branch}" \
+            --title "chore(spec): vendor GMNS spec ${TAG}" \
+            --body "$body"
+          # Label is optional — create-or-skip so first-run on a fresh
+          # repo doesn't fail the job.
+          gh pr edit "${branch}" --add-label spec-sync || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,20 @@ jobs:
         run: uv run pytest packages/datagrove/tests --doctest-modules packages/datagrove/datagrove
       - name: Test gmnspy
         run: uv run pytest packages/gmnspy/tests --doctest-modules packages/gmnspy/gmnspy
-      - name: Coverage report
+      # Coverage gates are per-package so a regression in one package
+       # can't be masked by overshoot in the other. Baseline measured
+       # 2026-05-26: datagrove 87%, gmnspy 85%. Gates set one point
+       # below current to flag regressions without flaking on noise.
+       # Per-package run is also more accurate — pytest --cov needs
+       # the package source mapped to test paths, and the workspace-
+       # wide run conflates the two.
+      - name: Coverage gate — datagrove ≥86%
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        run: uv run pytest packages/datagrove/tests --cov=datagrove --cov-fail-under=86 --cov-report=term
+      - name: Coverage gate — gmnspy ≥84%
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        run: uv run pytest packages/gmnspy/tests --cov=gmnspy --cov-fail-under=84 --cov-report=term
+      - name: Combined coverage XML for codecov upload
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: uv run pytest --cov --cov-report=xml --cov-report=term
       - name: Upload coverage

--- a/packages/gmnspy/Dockerfile
+++ b/packages/gmnspy/Dockerfile
@@ -1,0 +1,90 @@
+# gmnspy self-hostable HTTP server image.
+#
+# What it ships:
+#   - Python 3.13 slim base
+#   - gmnspy + datagrove from PyPI (built from source until v1.0 GA)
+#   - `[server]` extra (FastAPI + uvicorn + pydantic-settings + httpx)
+#   - `[mcp]` extra (lets the same image also serve `gmnspy mcp serve`)
+#   - `[clean]` extra (shapely + igraph + pyproj — many users want the
+#     full surface; image stays under 1 GB even with these)
+#
+# What it does NOT ship:
+#   - Your network data. Mount it at /data, point --config at it.
+#   - TLS termination. Put this behind your own reverse proxy.
+#   - Auth secrets. Pass via env or mounted config.
+#
+# Run:
+#   docker run --rm -p 8000:8000 \
+#       -v $(pwd)/config.yml:/etc/gmnspy/config.yml:ro \
+#       -v $(pwd)/data:/data:ro \
+#       ghcr.io/e-lo/gmnspy:latest
+#
+# Compose example: docker-compose.example.yml (next to this file).
+#
+# Build context: this file is in packages/gmnspy/ but the build needs
+# both packages/datagrove and packages/gmnspy (workspace install). CI
+# builds with `docker build -f packages/gmnspy/Dockerfile .` from the
+# REPO ROOT so both subtrees are in scope.
+
+FROM python:3.13-slim AS builder
+
+# uv for fast workspace install. Pin to a stable release.
+COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
+
+# OS packages required by some of the optional-extra wheels (mostly
+# the geo stack — shapely, pyproj — even though manylinux wheels are
+# the norm, having geos + proj headers keeps us safe on arches where
+# wheels aren't published).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgeos-c1v5 libproj25 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy the FULL workspace so uv can resolve datagrove as a local path
+# dependency. (datagrove isn't on PyPI yet at v1.0; once it is, we
+# can switch to `uv pip install gmnspy[server,mcp,clean]` here.)
+COPY pyproject.toml uv.lock ./
+COPY packages/ ./packages/
+
+# Install BOTH packages with the extras we want shipped.
+RUN uv venv /opt/gmnspy-venv \
+    && uv pip install --python /opt/gmnspy-venv/bin/python \
+        --no-cache \
+        -e ./packages/datagrove \
+        -e './packages/gmnspy[server,mcp,clean]'
+
+# ---------------------------------------------------------------------------
+# Runtime stage. Slim image, no build toolchain, just the venv + binaries.
+# ---------------------------------------------------------------------------
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgeos-c1v5 libproj25 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash gmnspy
+
+COPY --from=builder /opt/gmnspy-venv /opt/gmnspy-venv
+
+# Workspace source — gmnspy[server] is installed as editable so it
+# resolves back to these paths at import time. Strictly we could
+# `--no-editable` the wheel install above; keeping editable matches
+# what local devs see and makes hotfixing easier in a pinch.
+COPY --from=builder /build /workspace
+ENV PATH="/opt/gmnspy-venv/bin:${PATH}"
+
+WORKDIR /workspace
+USER gmnspy
+
+# Standard server port. Override with --port at run time.
+EXPOSE 8000
+
+# Default config lives at /etc/gmnspy/config.yml — mount your own
+# there. The `--bind 0.0.0.0` is required for the port to be
+# reachable from outside the container; behind a reverse proxy this
+# is fine. For direct exposure to the public internet, set up TLS
+# at the proxy layer and configure bearer auth in your config.
+CMD ["gmnspy", "server", "run", \
+     "--config", "/etc/gmnspy/config.yml", \
+     "--bind", "0.0.0.0", \
+     "--port", "8000"]

--- a/packages/gmnspy/docker-compose.example.yml
+++ b/packages/gmnspy/docker-compose.example.yml
@@ -1,0 +1,56 @@
+# Example docker-compose for self-hosting the gmnspy HTTP server.
+#
+# Copy this file to docker-compose.yml in your deployment directory,
+# adjust the volume paths + config + secrets, and `docker compose up -d`.
+#
+# This is an EXAMPLE — we don't ship a "blessed" compose config.
+# You're expected to put gmnspy behind your own reverse proxy
+# (Caddy / nginx / Traefik / ALB) for TLS termination and request
+# rate-limiting. The container only speaks plain HTTP on 0.0.0.0.
+
+services:
+  gmnspy-server:
+    image: ghcr.io/e-lo/gmnspy:latest
+    # If you build locally instead of pulling from ghcr.io:
+    #
+    # build:
+    #   context: ../..               # repo root — Dockerfile needs both packages/
+    #   dockerfile: packages/gmnspy/Dockerfile
+    container_name: gmnspy-server
+    restart: unless-stopped
+
+    # Bind to localhost only — your reverse proxy connects on the
+    # docker network or via the host loopback. Change to "8000:8000"
+    # for direct exposure (not recommended without TLS at the proxy).
+    ports:
+      - "127.0.0.1:8000:8000"
+
+    volumes:
+      # Server config. See `gmnspy server run --help` and
+      # `datagrove.api.ServerSettings` for the schema.
+      - ./config.yml:/etc/gmnspy/config.yml:ro
+      # Your network data. The config above should reference paths
+      # under /data (matches whatever you mount here).
+      - ./data:/data:ro
+
+    environment:
+      # Bearer token for the default auth backend. Use a strong value
+      # and rotate periodically. Read from a .env file (see below)
+      # rather than checking secrets into compose YAML.
+      DATAGROVE_API_BEARER_TOKEN: ${DATAGROVE_API_BEARER_TOKEN}
+
+      # Auto-approve any cost-model-gated operations. Required for
+      # the server: human-in-the-loop approval prompts don't make
+      # sense over HTTP. The HTTP routes that touch gated ops
+      # already pass approve=True; this is belt-and-suspenders for
+      # any code path that doesn't.
+      DATAGROVE_AUTO_APPROVE: "1"
+
+    # Healthcheck pokes /networks; expects a 200 + JSON. Adjust the
+    # path if your config exposes a different root route.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/networks"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,4 +193,10 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@overload",
 ]
-fail_under = 0  # raised to 85 (datagrove) / 75 (gmnspy) at Phase 5 closeout
+# Workspace-wide gate. Per-package gates are enforced separately in
+# the Tests workflow (datagrove ≥86%, gmnspy ≥84%) so a regression
+# in one package can't be masked by overshoot in the other. Baseline
+# measured 2026-05-26: combined 86%, datagrove 87%, gmnspy 85% —
+# gates set one point below current to flag regressions immediately
+# without flaking on stat-noise.
+fail_under = 85


### PR DESCRIPTION
## Summary

Knocks out 5 of 6 Phase 5 hardening sub-tasks in one PR. The remaining one (5.5 TestPyPI smoke) is blocked on user-side trusted-publishing setup and tracked separately.

| Task | Deliverable |
|---|---|
| 5.1 Coverage gate | Workspace `fail_under=85`; per-package gates `datagrove≥86%, gmnspy≥84%` (one point below current) |
| 5.2 Bench workflow | `.github/workflows/bench.yml` — pytest-benchmark on perf-critical paths, baseline diff, fails on >2x mean regression |
| 5.3 Spec-sync bot | `.github/workflows/spec-sync.yml` — daily cron; opens PR for each new upstream GMNS release |
| 5.4 release-drafter | `.github/release-drafter.yml` + workflow — auto-drafts notes by conventional-commit label |
| 5.6 Docker | `packages/gmnspy/Dockerfile` (multi-stage slim build) + `docker-compose.example.yml` |

## Decisions worth noting

- **Coverage:** gates set at current measured baseline minus 1pt cushion, not at the originally planned 85/75 (we already exceed that). Locks in the current investment.
- **Bench:** no bench tests exist yet — workflow no-ops cleanly until one lands. Discovery cascade handles three layout conventions.
- **Spec-sync:** one PR per run with idempotency guard so the cron doesn't force-push over in-flight reviews.
- **release-drafter:** one combined draft for v1.0 (per-package split documented as v1.1).
- **Docker:** workspace-context build (datagrove resolves as local path); non-root user; ghcr.io push on `gmnspy-v*` tags is wired in publish-gmnspy.yml (separate PR).

## Not in this PR

- **5.5 TestPyPI smoke** — needs you to set up trusted publishing on TestPyPI for both packages. Will land as its own PR with the verification script once tokens exist.
- **publish-gmnspy.yml Docker push step** — small follow-up edit; left out of this PR to keep scope to the new infrastructure.

## Test plan

- [x] `uv run pytest packages` → 1285 passing / 1 skipped / 0 xfails (no regression)
- [x] Ruff lint + format clean
- [x] All four new YAML files parse (yaml.safe_load)
- [x] Coverage gates pass locally: datagrove 87% ≥ 86, gmnspy 85% ≥ 84
- [ ] Manual: bench workflow no-ops on first run (no bench tests yet)
- [ ] Manual: spec-sync workflow finds no new versions (we already vendor 0.97, the upstream latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)